### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBLocalStorage.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBLocalStorage.m
@@ -12,7 +12,7 @@
 
 @synthesize isRefreshNeeded, deviceToken;
 
-static const NSString* storageVersion = @"v1.0.0";
+static NSString* const storageVersion = @"v1.0.0";
 
 - (SBLocalStorage*) initWithNotificationHubPath: (NSString*) notificationHubPath
 {
@@ -83,7 +83,7 @@ static const NSString* storageVersion = @"v1.0.0";
     StoredRegistrationEntry* reg = [[StoredRegistrationEntry alloc] init];
     
     reg.RegistrationName = [SBNotificationHubHelper nameOfRegistration:registration];
-    reg.registrationId = registration.registrationId;
+    reg.RegistrationId = registration.registrationId;
     reg.ETag = registration.ETag;
     
     [self->_registrations setValue:reg forKey:reg.RegistrationName];
@@ -98,7 +98,7 @@ static const NSString* storageVersion = @"v1.0.0";
     StoredRegistrationEntry* reg = [[StoredRegistrationEntry alloc] init];
     
     reg.RegistrationName = registrationName;
-    reg.registrationId = registrationId;
+    reg.RegistrationId = registrationId;
     reg.ETag = eTag;
     
     [self->_registrations setValue:reg forKey:reg.RegistrationName];

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBNotificationHubHelper.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBNotificationHubHelper.m
@@ -82,11 +82,11 @@ static NSString* decodingTableLock = @"decodingTableLock";
 		inputLength--;
 	}
 	
-	int outputLength = inputLength * 3 / 4;
+	NSUInteger outputLength = inputLength * 3 / 4;
 	NSMutableData* outputData = [NSMutableData dataWithLength:outputLength];
 	uint8_t* output = outputData.mutableBytes;
     
-    int outputPos = 0;
+    NSUInteger outputPos = 0;
     for (int i=0; i<inputLength; i += 4)
     {
         char i0 = input[i];


### PR DESCRIPTION
Fix the following compiler warnings:

`AzureNotificationHubs-iOS/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBLocalStorage.m:86:9: warning: property 'registrationId' not found on object of type 'StoredRegistrationEntry *'; did you mean to access property RegistrationId? [-Wproperty-access-dot-syntax]`

`AzureNotificationHubs-iOS/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBLocalStorage.m:132:68: warning: sending 'const NSString *__strong' to parameter of type 'NSString *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]`

`AzureNotificationHubs-iOS/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBNotificationHubHelper.m:85:37: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]`