### PR TITLE
Fixing BVT tests

### DIFF
--- a/src/WindowsAzureMessaging/BVT/IosSdkTests.xcodeproj/project.pbxproj
+++ b/src/WindowsAzureMessaging/BVT/IosSdkTests.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		700318A316BB0F5F00E30B98 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7003189E16BB0F5F00E30B98 /* Default-568h@2x.png */; };
 		700318A416BB0F5F00E30B98 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 7003189F16BB0F5F00E30B98 /* Default.png */; };
 		700318A516BB0F5F00E30B98 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 700318A016BB0F5F00E30B98 /* Default@2x.png */; };
-		700318A616BB0F5F00E30B98 /* IosSdkTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 700318A116BB0F5F00E30B98 /* IosSdkTests-Info.plist */; };
 		700318AC16BB113F00E30B98 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 700318AB16BB113F00E30B98 /* QuartzCore.framework */; };
 		84BB3070174FE289007D364D /* RegistrationRetriever.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BB306F174FE289007D364D /* RegistrationRetriever.m */; };
 		84BB3076174FE360007D364D /* Registration.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BB3073174FE35F007D364D /* Registration.m */; };
@@ -34,6 +33,9 @@
 		84BB307E174FF1E3007D364D /* GHUnitIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84BB307D174FF1E3007D364D /* GHUnitIOS.framework */; };
 		84BB30F517664F6C007D364D /* WindowsAzureMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84BB30F417664F6C007D364D /* WindowsAzureMessaging.framework */; };
 		84BB30F817665027007D364D /* NHSolutionMgr.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BB30F717665027007D364D /* NHSolutionMgr.m */; };
+		B3821CC82459B03700567643 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = B3821CC72459B03700567643 /* libz.tbd */; };
+		B3821CCA2459B03E00567643 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3821CC92459B03E00567643 /* SystemConfiguration.framework */; };
+		B3821CCC2459B0E500567643 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3821CCB2459B0E500567643 /* UserNotifications.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -83,6 +85,9 @@
 		84BB30F417664F6C007D364D /* WindowsAzureMessaging.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = WindowsAzureMessaging.framework; sourceTree = "<group>"; };
 		84BB30F61766501A007D364D /* NHSolutionMgr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NHSolutionMgr.h; sourceTree = "<group>"; };
 		84BB30F717665027007D364D /* NHSolutionMgr.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NHSolutionMgr.m; sourceTree = "<group>"; };
+		B3821CC72459B03700567643 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		B3821CC92459B03E00567643 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		B3821CCB2459B0E500567643 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +95,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3821CCC2459B0E500567643 /* UserNotifications.framework in Frameworks */,
+				B3821CCA2459B03E00567643 /* SystemConfiguration.framework in Frameworks */,
+				B3821CC82459B03700567643 /* libz.tbd in Frameworks */,
 				700318AC16BB113F00E30B98 /* QuartzCore.framework in Frameworks */,
 				7003178016BB058200E30B98 /* UIKit.framework in Frameworks */,
 				7003178216BB058200E30B98 /* Foundation.framework in Frameworks */,
@@ -124,6 +132,9 @@
 		7003177E16BB058200E30B98 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B3821CCB2459B0E500567643 /* UserNotifications.framework */,
+				B3821CC92459B03E00567643 /* SystemConfiguration.framework */,
+				B3821CC72459B03700567643 /* libz.tbd */,
 				84BB30F417664F6C007D364D /* WindowsAzureMessaging.framework */,
 				84BB307D174FF1E3007D364D /* GHUnitIOS.framework */,
 				700318AB16BB113F00E30B98 /* QuartzCore.framework */,
@@ -269,15 +280,16 @@
 		7003177216BB058200E30B98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = arunks;
 			};
 			buildConfigurationList = 7003177516BB058200E30B98 /* Build configuration list for PBXProject "IosSdkTests" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 7003177016BB058200E30B98;
 			productRefGroup = 7003177C16BB058200E30B98 /* Products */;
@@ -297,7 +309,6 @@
 				700318A316BB0F5F00E30B98 /* Default-568h@2x.png in Resources */,
 				700318A416BB0F5F00E30B98 /* Default.png in Resources */,
 				700318A516BB0F5F00E30B98 /* Default@2x.png in Resources */,
-				700318A616BB0F5F00E30B98 /* IosSdkTests-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -351,25 +362,47 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TEST_AFTER_BUILD = NO;
@@ -380,18 +413,39 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				TEST_AFTER_BUILD = NO;
@@ -421,6 +475,7 @@
 					"-all_load",
 					"-ObjC",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "MS.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
@@ -449,6 +504,7 @@
 					"-all_load",
 					"-ObjC",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "MS.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;

--- a/src/WindowsAzureMessaging/BVT/IosSdkTests.xcodeproj/xcshareddata/xcschemes/IosSdkTests.xcscheme
+++ b/src/WindowsAzureMessaging/BVT/IosSdkTests.xcodeproj/xcshareddata/xcschemes/IosSdkTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:IosSdkTests.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:IosSdkTests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/src/WindowsAzureMessaging/BVT/IosSdkTests/IosSdkTests-Info.plist
+++ b/src/WindowsAzureMessaging/BVT/IosSdkTests/IosSdkTests-Info.plist
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Namespace</key>
-	<string>INT7-SN1-004</string>
-	<key>NotificationHub</key>
-	<string></string>
-	<key>SecretKey</key>
-	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -15,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>MS.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -30,6 +24,12 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>Namespace</key>
+	<string>INT7-SN1-004</string>
+	<key>NotificationHub</key>
+	<string></string>
+	<key>SecretKey</key>
+	<string></string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
@@ -121,6 +121,13 @@
 		B34BA7A52458A128002457DC /* WindowsAzureMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 906E404016A86A3200817A11 /* WindowsAzureMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B34BA7A62458A131002457DC /* SBStaticHandlerResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 929886EF1857FAB100C1676C /* SBStaticHandlerResponse.h */; };
 		B34BA7A72458A135002457DC /* SBStaticHandlerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 92988747185931DE00C1676C /* SBStaticHandlerResponse.m */; };
+		B3821CC02459AFB500567643 /* MS_Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D285512456F09900C78CC8 /* MS_Reachability.m */; };
+		B3821CC12459AFB800567643 /* MS_Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D285522456F09900C78CC8 /* MS_Reachability.h */; };
+		B3821CC22459AFCB00567643 /* MSInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8546FC244F8F49005F6B49 /* MSInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B3821CC32459AFD000567643 /* MSInstallationTemplate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8546FD244F8FB4005F6B49 /* MSInstallationTemplate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B3821CC42459AFD400567643 /* MSNotificationHubMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8546FE244F9075005F6B49 /* MSNotificationHubMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B3821CC52459AFDC00567643 /* MSNotificationHub.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C854703244F9347005F6B49 /* MSNotificationHub.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B3821CC62459AFE300567643 /* MSNotificationHubMessageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C854704244F95A7005F6B49 /* MSNotificationHubMessageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3D285272456E97F00C78CC8 /* MSHttpClientProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D2851E2456E97E00C78CC8 /* MSHttpClientProtocol.h */; };
 		B3D285282456E97F00C78CC8 /* MSHttpClientProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D2851E2456E97E00C78CC8 /* MSHttpClientProtocol.h */; };
 		B3D285292456E97F00C78CC8 /* MSHttpClient.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2851F2456E97E00C78CC8 /* MSHttpClient.m */; };
@@ -580,6 +587,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3821CC22459AFCB00567643 /* MSInstallation.h in Headers */,
 				B3D2855C2456F1F200C78CC8 /* MSHttpClientDelegate.h in Headers */,
 				B3D285312456E97F00C78CC8 /* MSHttpUtil.h in Headers */,
 				A358373916AA3B060041E372 /* SBConnectionString.h in Headers */,
@@ -591,10 +599,15 @@
 				A358373C16AA3B0B0041E372 /* SBRegistration.h in Headers */,
 				848CB73C16FCC78E00183E8D /* SBStoredRegistrationEntry.h in Headers */,
 				B3D2852D2456E97F00C78CC8 /* MSHttpClientPrivate.h in Headers */,
+				B3821CC32459AFD000567643 /* MSInstallationTemplate.h in Headers */,
 				A358373E16AA3B120041E372 /* SBNotificationHubHelper.h in Headers */,
 				A358374116AA3B190041E372 /* SBURLConnection.h in Headers */,
+				B3821CC62459AFE300567643 /* MSNotificationHubMessageDelegate.h in Headers */,
+				B3821CC52459AFDC00567643 /* MSNotificationHub.h in Headers */,
 				B3D285272456E97F00C78CC8 /* MSHttpClientProtocol.h in Headers */,
 				B3D2852F2456E97F00C78CC8 /* MSHttpClient.h in Headers */,
+				B3821CC12459AFB800567643 /* MS_Reachability.h in Headers */,
+				B3821CC42459AFD400567643 /* MSNotificationHubMessage.h in Headers */,
 				B3D285492456EDD800C78CC8 /* MSConstants+Internal.h in Headers */,
 				848CB70A16FBE52D00183E8D /* SBTemplateRegistration.h in Headers */,
 				B3D2854B2456EDD800C78CC8 /* MSCompression.h in Headers */,
@@ -816,6 +829,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3821CC02459AFB500567643 /* MS_Reachability.m in Sources */,
 				A358374216AA3B1B0041E372 /* SBNotificationHubHelper.m in Sources */,
 				B3D285592456F0E700C78CC8 /* MSDispatcherUtil.m in Sources */,
 				B3D2852B2456E97F00C78CC8 /* MSHttpCall.m in Sources */,


### PR DESCRIPTION
After adding HttpClient, additional requirements for linked framework appeared.
In this PR we are modified existing BVT app, we verified that BVT is working and enable it in iOS-pipeline