### PR TITLE
Adds Clang Formatting

### DIFF
--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/.clang-format
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+ColumnLimit: 140
+UseTab: Never

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.h
@@ -4,12 +4,12 @@
 #ifndef MSNotificationHub_h
 #define MSNotificationHub_h
 
-#import <Foundation/Foundation.h>
-#import "MSTokenProvider.h"
-#import "MSLocalStorage.h"
 #import "MSInstallationTemplate.h"
-#import "MSNotificationHubMessage.h"
+#import "MSLocalStorage.h"
 #import "MSNotificationHubDelegate.h"
+#import "MSNotificationHubMessage.h"
+#import "MSTokenProvider.h"
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * The Azure Notification Hubs service
-*/
+ */
 @interface MSNotificationHub : NSObject
 
 @property(nonatomic, copy, readonly) MSInstallation *installation;
@@ -30,10 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) id<MSNotificationHubDelegate> delegate;
 
 /**
- * Initializes the Notification Hub with the connection string from the Access Policy, and Hub Name.
+ * Initializes the Notification Hub with the connection string from the Access
+ * Policy, and Hub Name.
  * @param connectionString The connection string
  */
-+ (void)initWithConnectionString:(NSString *) connectionString withHubName:(NSString*)notificationHubName;
++ (void)initWithConnectionString:(NSString *)connectionString withHubName:(NSString *)notificationHubName;
 
 #pragma mark Push Initialization
 
@@ -63,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (MSInstallationTemplate *)getTemplate:(NSString *)key;
 
 #pragma mark Installation Support
-+ (MSInstallation *) getInstallation;
++ (MSInstallation *)getInstallation;
 
 #pragma mark Helpers
 // TODO: Move into internal

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.m
@@ -1,31 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#import <UserNotifications/UserNotifications.h>
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 
-#import "MSNotificationHub.h"
-#import "MSInstallationManager.h"
 #import "MSInstallation.h"
+#import "MSInstallationManager.h"
 #import "MSInstallationTemplate.h"
+#import "MSNotificationHub.h"
 #import "MSNotificationHubMessage.h"
 
 // Singleton
 static MSNotificationHub *sharedInstance = nil;
 static dispatch_once_t onceToken;
- 
+
 @implementation MSNotificationHub
 
 @synthesize templates;
 
 - (instancetype)init {
-    if ((self = [super init])) {
-        templates = [NSMutableDictionary new];
-        
-        [self registerForRemoteNotifications];
-    }
-    
-    return self;
+  if ((self = [super init])) {
+    templates = [NSMutableDictionary new];
+
+    [self registerForRemoteNotifications];
+  }
+
+  return self;
 }
 
 + (instancetype)sharedInstance {
@@ -37,26 +37,31 @@ static dispatch_once_t onceToken;
   return sharedInstance;
 }
 
-+ (void)initWithConnectionString:(NSString *) connectionString withHubName:(NSString*)notificationHubName {
-    [MSInstallationManager initWithConnectionString:connectionString withHubName: notificationHubName];
++ (void)initWithConnectionString:(NSString *)connectionString withHubName:(NSString *)notificationHubName {
+  [MSInstallationManager initWithConnectionString:connectionString withHubName:notificationHubName];
 }
 
 - (void)registerForRemoteNotifications {
   if (@available(iOS 10.0, *)) {
-      UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-      UNAuthorizationOptions authOptions = (UNAuthorizationOptions)(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge);
-      [center requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError *_Nullable error) {
-          if (granted) {
-              NSLog(@"Push notifications authorization was granted.");
-          } else {
-              NSLog(@"Push notifications authorization was denied.");
-          }
-          if (error) {
-              NSLog(@"Push notifications authorization request has been finished with error: %@", error.localizedDescription);
-          }
-      }];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    UNAuthorizationOptions authOptions =
+        (UNAuthorizationOptions)(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge);
+    [center requestAuthorizationWithOptions:authOptions
+                          completionHandler:^(BOOL granted, NSError *_Nullable error) {
+                            if (granted) {
+                              NSLog(@"Push notifications authorization was granted.");
+                            } else {
+                              NSLog(@"Push notifications authorization was denied.");
+                            }
+                            if (error) {
+                              NSLog(@"Push notifications authorization request has "
+                                    @"been finished with error: %@",
+                                    error.localizedDescription);
+                            }
+                          }];
   } else {
-    UIUserNotificationType allNotificationTypes = (UIUserNotificationType)(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
+    UIUserNotificationType allNotificationTypes =
+        (UIUserNotificationType)(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
     UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
     [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
   }
@@ -64,28 +69,27 @@ static dispatch_once_t onceToken;
 }
 
 - (BOOL)didReceiveRemoteNotification:(NSDictionary *)userInfo {
-    MSNotificationHubMessage *message = [MSNotificationHubMessage createFromNotification:userInfo];
-    [self didReceivePushNotification:message];
-    
-    if(message.additionalData)
-    {
-        return YES;
-    }
-    return NO;
+  MSNotificationHubMessage *message = [MSNotificationHubMessage createFromNotification:userInfo];
+  [self didReceivePushNotification:message];
+
+  if (message.additionalData) {
+    return YES;
+  }
+  return NO;
 }
 
 #pragma mark Instance Callbacks
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    NSString *pushToken = [self convertTokenToString:deviceToken];
-    NSLog(@"Registered for push notifications with token: %@", pushToken);
-    
-    [MSInstallationManager setPushChannel: pushToken];
-    [MSInstallationManager saveInstallation];
+  NSString *pushToken = [self convertTokenToString:deviceToken];
+  NSLog(@"Registered for push notifications with token: %@", pushToken);
+
+  [MSInstallationManager setPushChannel:pushToken];
+  [MSInstallationManager saveInstallation];
 }
 
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-    NSLog(@"Registering for push notifications has been finished with error: %@", error.localizedDescription);
+  NSLog(@"Registering for push notifications has been finished with error: %@", error.localizedDescription);
 }
 
 - (void)didReceivePushNotification:(MSNotificationHubMessage *)notification {
@@ -100,25 +104,24 @@ static dispatch_once_t onceToken;
 #pragma mark Register Callbacks
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    [sharedInstance didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+  [sharedInstance didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-    [sharedInstance didFailToRegisterForRemoteNotificationsWithError:error];
+  [sharedInstance didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
 + (BOOL)didReceiveRemoteNotification:(NSDictionary *)userInfo {
-    return [sharedInstance didReceiveRemoteNotification:userInfo];
+  return [sharedInstance didReceiveRemoteNotification:userInfo];
 }
 
 #pragma mark SDK Basics
 
 + (void)setEnabled:(BOOL)isEnabled {
-    
 }
 
 + (BOOL)isEnabled {
-    return YES;
+  return YES;
 }
 
 + (void)setDelegate:(nullable id<MSNotificationHubDelegate>)delegate {
@@ -128,68 +131,68 @@ static dispatch_once_t onceToken;
 #pragma mark Tags
 
 + (BOOL)addTag:(NSString *)tag {
-    return [MSNotificationHub addTags:[NSArray arrayWithObject:tag]];
+  return [MSNotificationHub addTags:[NSArray arrayWithObject:tag]];
 }
 
 + (BOOL)addTags:(NSArray<NSString *> *)tags {
-    if([MSInstallationManager addTags:tags]) {
-        [MSInstallationManager saveInstallation];
-        return YES;
-    }
-    
-    return NO;
+  if ([MSInstallationManager addTags:tags]) {
+    [MSInstallationManager saveInstallation];
+    return YES;
+  }
+
+  return NO;
 }
 
 + (BOOL)removeTag:(NSString *)tag {
-    return [MSNotificationHub removeTags:[NSArray arrayWithObject:tag]];
+  return [MSNotificationHub removeTags:[NSArray arrayWithObject:tag]];
 }
 
 + (BOOL)removeTags:(NSArray<NSString *> *)tags {
-    if(![MSInstallationManager removeTags:tags]) {
-        return NO;
-    }
-    
-    [MSInstallationManager saveInstallation];
-    
-    return YES;
+  if (![MSInstallationManager removeTags:tags]) {
+    return NO;
+  }
+
+  [MSInstallationManager saveInstallation];
+
+  return YES;
 }
 
 + (NSArray<NSString *> *)getTags {
-    return [MSInstallationManager getTags];
+  return [MSInstallationManager getTags];
 }
 
 + (void)clearTags {
-    [MSInstallationManager clearTags];
-    [MSInstallationManager saveInstallation];
+  [MSInstallationManager clearTags];
+  [MSInstallationManager saveInstallation];
 }
 
 #pragma mark Templates
 
 + (void)setTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key {
-    [[MSNotificationHub sharedInstance] setInstallationTemplate:template forKey:key];
+  [[MSNotificationHub sharedInstance] setInstallationTemplate:template forKey:key];
 }
 
 + (void)removeTemplate:(NSString *)key {
-    [[MSNotificationHub sharedInstance] removeInstallationTemplate:key];
+  [[MSNotificationHub sharedInstance] removeInstallationTemplate:key];
 }
 
 + (MSInstallationTemplate *)getTemplate:(NSString *)name {
-    return nil;
+  return nil;
 }
 
 - (void)setInstallationTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key {
-    // TODO: Store in local storage and mark as dirty
-    [self.templates setValue:template forKey:key];
+  // TODO: Store in local storage and mark as dirty
+  [self.templates setValue:template forKey:key];
 }
 
 - (void)removeInstallationTemplate:(NSString *)key {
-    [self.templates removeObjectForKey:key];
+  [self.templates removeObjectForKey:key];
 }
 
 #pragma mark Installation
 
-+ (MSInstallation *) getInstallation {
-    return [MSInstallationManager getInstallation];
++ (MSInstallation *)getInstallation {
+  return [MSInstallationManager getInstallation];
 }
 
 #pragma mark Helpers

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHubDelegate.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHubDelegate.h
@@ -11,8 +11,8 @@
 @optional
 
 /**
- * Callback method that will be called whenever a push notification is clicked from notification center or a notification is received in
- * foreground.
+ * Callback method that will be called whenever a push notification is clicked
+ * from notification center or a notification is received in foreground.
  *
  * @param notificationHub The instance of MSNotificationHub
  * @param message The push notification details.

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBConnectionString.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBConnectionString.h
@@ -6,12 +6,12 @@
 
 @interface SBConnectionString : NSObject
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint issuer:(NSString*) issuer issuerSecret:(NSString*)secret;
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint issuer:(NSString *)issuer issuerSecret:(NSString *)secret;
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint fullAccessSecret:(NSString*)fullAccessSecret;
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint fullAccessSecret:(NSString *)fullAccessSecret;
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint listenAccessSecret:(NSString*)listenAccessSecret;
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint listenAccessSecret:(NSString *)listenAccessSecret;
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint sharedAccessKeyName:(NSString*)keyName accessSecret:(NSString*)secret;
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint sharedAccessKeyName:(NSString *)keyName accessSecret:(NSString *)secret;
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBConnectionString.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBConnectionString.m
@@ -7,61 +7,48 @@
 
 @implementation SBConnectionString
 
-NSString* const defaultListenSasRuleName = @"DefaultListenSharedAccessSignature";
-NSString* const defaultFullSasRuleName = @"DefaultFullSharedAccessSignature";
+NSString *const defaultListenSasRuleName = @"DefaultListenSharedAccessSignature";
+NSString *const defaultFullSasRuleName = @"DefaultFullSharedAccessSignature";
 
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint issuer:(NSString *)issuer issuerSecret:(NSString *)secret {
+  if (!endpoint || !issuer || !secret) {
+    NSLog(@"endpoint/issuer/secret can't be null.");
+    return nil;
+  }
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint issuer:(NSString*) issuer issuerSecret:(NSString*)secret
-{
-    if(!endpoint || !issuer || !secret)
-    {
-        NSLog(@"endpoint/issuer/secret can't be null.");
-        return nil;
-    }
-    
-    endpoint = [SBNotificationHubHelper modifyEndpoint:endpoint scheme:@"sb"];
-    
-    NSString* endpointUri = [endpoint absoluteString];
-    if([[endpointUri lowercaseString] hasPrefix:@"endpoint="])
-    {
-        return [NSString stringWithFormat:@"%@;SharedSecretIssuer=%@;SharedSecretValue=%@",endpointUri,issuer,secret];
-    }
-    else
-    {
-        return [NSString stringWithFormat:@"Endpoint=%@;SharedSecretIssuer=%@;SharedSecretValue=%@",endpointUri,issuer,secret];
-    }
+  endpoint = [SBNotificationHubHelper modifyEndpoint:endpoint scheme:@"sb"];
+
+  NSString *endpointUri = [endpoint absoluteString];
+  if ([[endpointUri lowercaseString] hasPrefix:@"endpoint="]) {
+    return [NSString stringWithFormat:@"%@;SharedSecretIssuer=%@;SharedSecretValue=%@", endpointUri, issuer, secret];
+  } else {
+    return [NSString stringWithFormat:@"Endpoint=%@;SharedSecretIssuer=%@;SharedSecretValue=%@", endpointUri, issuer, secret];
+  }
 }
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint fullAccessSecret:(NSString*)fullAccessSecret
-{
-    return [SBConnectionString stringWithEndpoint:endpoint sharedAccessKeyName:defaultFullSasRuleName accessSecret:fullAccessSecret];
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint fullAccessSecret:(NSString *)fullAccessSecret {
+  return [SBConnectionString stringWithEndpoint:endpoint sharedAccessKeyName:defaultFullSasRuleName accessSecret:fullAccessSecret];
 }
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint listenAccessSecret:(NSString*)listenAccessSecret
-{
-    return [SBConnectionString stringWithEndpoint:endpoint sharedAccessKeyName:defaultListenSasRuleName accessSecret:listenAccessSecret];
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint listenAccessSecret:(NSString *)listenAccessSecret {
+  return [SBConnectionString stringWithEndpoint:endpoint sharedAccessKeyName:defaultListenSasRuleName accessSecret:listenAccessSecret];
 }
 
-+ (NSString*) stringWithEndpoint:(NSURL*)endpoint sharedAccessKeyName:(NSString*)keyName accessSecret:(NSString*)secret
-{
-    if(!endpoint || !keyName || !secret)
-    {
-        NSLog(@"endpoint/keyName/secret can't be null.");
-        return nil;
-    }
-    
-    endpoint = [SBNotificationHubHelper modifyEndpoint:endpoint scheme:@"sb"];
-    
-    NSString* endpointUri = [endpoint absoluteString];
-    
-    if([[endpointUri lowercaseString] hasPrefix:@"endpoint="])
-    {
-        return [NSString stringWithFormat:@"%@;SharedAccessKeyName=%@;SharedAccessKey=%@",endpointUri,keyName,secret];
-    }
-    else
-    {
-        return [NSString stringWithFormat:@"Endpoint=%@;SharedAccessKeyName=%@;SharedAccessKey=%@",endpointUri,keyName,secret];
-    }
++ (NSString *)stringWithEndpoint:(NSURL *)endpoint sharedAccessKeyName:(NSString *)keyName accessSecret:(NSString *)secret {
+  if (!endpoint || !keyName || !secret) {
+    NSLog(@"endpoint/keyName/secret can't be null.");
+    return nil;
+  }
+
+  endpoint = [SBNotificationHubHelper modifyEndpoint:endpoint scheme:@"sb"];
+
+  NSString *endpointUri = [endpoint absoluteString];
+
+  if ([[endpointUri lowercaseString] hasPrefix:@"endpoint="]) {
+    return [NSString stringWithFormat:@"%@;SharedAccessKeyName=%@;SharedAccessKey=%@", endpointUri, keyName, secret];
+  } else {
+    return [NSString stringWithFormat:@"Endpoint=%@;SharedAccessKeyName=%@;SharedAccessKey=%@", endpointUri, keyName, secret];
+  }
 }
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBNotificationHub.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBNotificationHub.h
@@ -4,41 +4,61 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SBTokenProvider.h"
 #import "SBLocalStorage.h"
+#import "SBTokenProvider.h"
 
-
-@interface SBNotificationHub : NSObject
-{
+@interface SBNotificationHub : NSObject {
 @private
-    NSString* _path;
-    NSURL* _serviceEndPoint;
-    SBTokenProvider* tokenProvider;
-    SBLocalStorage* storageManager;
+  NSString *_path;
+  NSURL *_serviceEndPoint;
+  SBTokenProvider *tokenProvider;
+  SBLocalStorage *storageManager;
 }
 
-+ (NSString*) version;
++ (NSString *)version;
 
-- (SBNotificationHub*) initWithConnectionString:(NSString*) connectionString notificationHubPath:(NSString*)notificationHubPath;
+- (SBNotificationHub *)initWithConnectionString:(NSString *)connectionString notificationHubPath:(NSString *)notificationHubPath;
 
 // Async operations
-- (void) registerNativeWithDeviceToken:(NSData*)deviceToken tags:(NSSet*)tags completion:(void (^)(NSError* error))completion;
-- (void) registerTemplateWithDeviceToken:(NSData*)deviceToken name:(NSString*)name jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate tags:(NSSet*)tags completion:(void (^)(NSError* error))completion;
-- (void) registerTemplateWithDeviceToken:(NSData*)deviceToken name:(NSString*)name jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate priorityTemplate:(NSString*)priorityTemplate tags:(NSSet*)tags completion:(void (^)(NSError* error))completion;
+- (void)registerNativeWithDeviceToken:(NSData *)deviceToken tags:(NSSet *)tags completion:(void (^)(NSError *error))completion;
+- (void)registerTemplateWithDeviceToken:(NSData *)deviceToken
+                                   name:(NSString *)name
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                                   tags:(NSSet *)tags
+                             completion:(void (^)(NSError *error))completion;
+- (void)registerTemplateWithDeviceToken:(NSData *)deviceToken
+                                   name:(NSString *)name
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                       priorityTemplate:(NSString *)priorityTemplate
+                                   tags:(NSSet *)tags
+                             completion:(void (^)(NSError *error))completion;
 
-- (void) unregisterNativeWithCompletion:(void (^)(NSError* error))completion;
-- (void) unregisterTemplateWithName:(NSString*)name completion:(void (^)(NSError* error))completion;
+- (void)unregisterNativeWithCompletion:(void (^)(NSError *error))completion;
+- (void)unregisterTemplateWithName:(NSString *)name completion:(void (^)(NSError *error))completion;
 
-- (void) unregisterAllWithDeviceToken:(NSData*)deviceToken completion:(void (^)(NSError* error))completion;
+- (void)unregisterAllWithDeviceToken:(NSData *)deviceToken completion:(void (^)(NSError *error))completion;
 
 // sync operations
-- (BOOL) registerNativeWithDeviceToken:(NSData*)deviceToken tags:(NSSet*)tags error:(NSError**)error;
-- (BOOL) registerTemplateWithDeviceToken:(NSData*)deviceToken name:(NSString*)templateName jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate tags:(NSSet*)tags error:(NSError**)error;
-- (BOOL) registerTemplateWithDeviceToken:(NSData*)deviceToken name:(NSString*)templateName jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate priorityTemplate:(NSString*)priorityTemplate tags:(NSSet*)tags error:(NSError**)error;
+- (BOOL)registerNativeWithDeviceToken:(NSData *)deviceToken tags:(NSSet *)tags error:(NSError **)error;
+- (BOOL)registerTemplateWithDeviceToken:(NSData *)deviceToken
+                                   name:(NSString *)templateName
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                                   tags:(NSSet *)tags
+                                  error:(NSError **)error;
+- (BOOL)registerTemplateWithDeviceToken:(NSData *)deviceToken
+                                   name:(NSString *)templateName
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                       priorityTemplate:(NSString *)priorityTemplate
+                                   tags:(NSSet *)tags
+                                  error:(NSError **)error;
 
-- (BOOL) unregisterNativeWithError:(NSError**)error;
-- (BOOL) unregisterTemplateWithName:(NSString*)name error:(NSError**)error;
+- (BOOL)unregisterNativeWithError:(NSError **)error;
+- (BOOL)unregisterTemplateWithName:(NSString *)name error:(NSError **)error;
 
-- (BOOL) unregisterAllWithDeviceToken:(NSData*)deviceToken error:(NSError**)error;
+- (BOOL)unregisterAllWithDeviceToken:(NSData *)deviceToken error:(NSError **)error;
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBNotificationHub.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBNotificationHub.m
@@ -3,23 +3,23 @@
 //----------------------------------------------------------------
 
 #import "SBNotificationHub.h"
-#import "SBNotificationHubHelper.h"
-#import "SBTokenProvider.h"
-#import "SBRegistrationParser.h"
-#import "SBURLConnection.h"
 #import "SBLocalStorage.h"
+#import "SBNotificationHubHelper.h"
 #import "SBRegistration.h"
+#import "SBRegistrationParser.h"
 #import "SBTemplateRegistration.h"
+#import "SBTokenProvider.h"
+#import "SBURLConnection.h"
 #import <UIKit/UIKit.h>
 
-typedef void (^SBCompletion)(NSError*);
+typedef void (^SBCompletion)(NSError *);
 
 @interface SBThreadParameter : NSObject
 
-@property (copy, nonatomic) NSArray* parameters;
-@property (copy, nonatomic) NSString* deviceToken;
-@property (copy, nonatomic) SBCompletion completion;
-@property (nonatomic) BOOL isMainThread;
+@property(copy, nonatomic) NSArray *parameters;
+@property(copy, nonatomic) NSString *deviceToken;
+@property(copy, nonatomic) SBCompletion completion;
+@property(nonatomic) BOOL isMainThread;
 
 @end
 
@@ -30,968 +30,920 @@ typedef void (^SBCompletion)(NSError*);
 
 @implementation SBNotificationHub
 
-NSString* const currentVersion = @"v0.1.6";
-NSString* const _APIVersion = @"2013-04";
-NSString* const _UserAgentTemplate = @"NOTIFICATIONHUBS/%@(api-origin=IosSdk; os=%@; os_version=%@;)";
+NSString *const currentVersion = @"v0.1.6";
+NSString *const _APIVersion = @"2013-04";
+NSString *const _UserAgentTemplate = @"NOTIFICATIONHUBS/%@(api-origin=IosSdk; os=%@; os_version=%@;)";
 
-- (SBNotificationHub*) initWithConnectionString:(NSString*) connectionString notificationHubPath:(NSString*)notificationHubPath
-{
-    self = [super init];
-    
-    if(!connectionString || !notificationHubPath)
-    {
-        return nil;
-    }
-    
-    if( self){
-        NSDictionary* connnectionDictionary = [SBNotificationHubHelper parseConnectionString:connectionString];
-        
-        NSString* endPoint = [connnectionDictionary objectForKey:@"endpoint"];
-        if(endPoint)
-        {
-            self->_serviceEndPoint = [[NSURL alloc] initWithString:endPoint];
-        }
-        
-        if(self->_serviceEndPoint == nil || [self->_serviceEndPoint host] == nil)
-        {
-            NSLog(@"%@",@"Endpoint is missing or not in URL format in connectionString.");
-            return nil;
-        }
-        
-        self->_path = notificationHubPath;
-        tokenProvider = [[SBTokenProvider alloc] initWithConnectionDictinary:connnectionDictionary];
-        
-        if(tokenProvider == nil)
-        {
-            return nil;
-        }
-        
-        storageManager = [[SBLocalStorage alloc] initWithNotificationHubPath:notificationHubPath];
-        
-        if(storageManager == nil)
-        {
-            return nil;
-        }
-    }
-    
-    return self;
-}
+- (SBNotificationHub *)initWithConnectionString:(NSString *)connectionString notificationHubPath:(NSString *)notificationHubPath {
+  self = [super init];
 
-- (NSString *)convertDeviceToken:(NSData *)deviceTokenData
-{
-    const char *data = [deviceTokenData bytes];
-    NSMutableString *newDeviceToken = [NSMutableString string];
-    
-    for (NSUInteger i = 0; i < [deviceTokenData length]; i++) {
-        [newDeviceToken appendFormat:@"%02.2hhX", data[i]];
-    }
-    
-    return [newDeviceToken copy];
-}
-
-- (void) registerNativeWithDeviceToken:(NSData*)deviceTokenData tags:(NSSet*)tags completion:(void (^)(NSError* error))completion;
-{
-    if( deviceTokenData == nil)
-    {
-        if(completion)
-        {
-            completion([SBNotificationHubHelper errorForNullDeviceToken]);
-        }
-        
-        return;
-    }
-    
-    NSString* deviceToken = [self convertDeviceToken:deviceTokenData];
-    NSString* name = [SBRegistration Name];
-    NSString* payload = [SBRegistration payloadWithDeviceToken:deviceToken tags:tags];
-    
-    if( storageManager.isRefreshNeeded)
-    {
-        NSString* refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
-        [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken completion:^(NSArray * regs, NSError * error)
-        {
-            if( error == nil)
-            {
-                [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
-                [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
-            }
-            else
-            {
-                if( completion)
-                {
-                    completion(error);
-                }
-            }
-        }];
-    }
-    else
-    {
-        [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
-    }
-}
-
-- (void) registerTemplateWithDeviceToken:(NSData*)deviceTokenData name:(NSString*)name jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate tags:(NSSet*)tags completion:(void (^)(NSError* error))completion;
-{
-    [self registerTemplateWithDeviceToken:deviceTokenData name:name jsonBodyTemplate:bodyTemplate expiryTemplate:expiryTemplate priorityTemplate:nil tags:tags completion:completion];
-}
-
-- (void) registerTemplateWithDeviceToken:(NSData*)deviceTokenData name:(NSString*)name jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate priorityTemplate:(NSString*)priorityTemplate tags:(NSSet*)tags completion:(void (^)(NSError* error))completion;
-{
-    if( deviceTokenData == nil)
-    {
-        if(completion)
-        {
-            completion([SBNotificationHubHelper errorForNullDeviceToken]);
-        }
-        
-        return;
-    }
-    
-    NSString* deviceToken = [self convertDeviceToken:deviceTokenData];
-    
-    NSError* error;
-    if( [self verifyTemplateName:name error:&error] == FALSE)
-    {
-        if(completion)
-        {
-            completion(error);
-        }
-        
-        return;
-    }
-    
-    NSString* payload = [SBTemplateRegistration payloadWithDeviceToken:deviceToken bodyTemplate:bodyTemplate expiryTemplate:expiryTemplate priorityTemplate:priorityTemplate tags:tags templateName:name];
-    
-    if( storageManager.isRefreshNeeded)
-    {
-        NSString* refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
-        [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken completion:^(NSArray * regs, NSError * error)
-         {
-             if( error == nil)
-             {
-                 [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
-                 [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
-             }
-             else
-             {
-                 if( completion)
-                 {
-                     completion(error);
-                 }
-             }
-         }];
-    }
-    else
-    {
-        [self createOrUpdateWith:name payload:payload  deviceToken:deviceToken completion:completion];
-    }
-}
-
-- (void)createOrUpdateWith:(NSString *)name payload:(NSString *)payload deviceToken:(NSString *)deviceToken completion:(void (^)(NSError *))completion
-{
-    StoredRegistrationEntry* cached = [storageManager getStoredRegistrationEntryWithRegistrationName:name];
-    if(cached == nil)
-    {
-        [self createRegistrationIdAndUpsert:name payload:payload deviceToken:deviceToken completion:^(NSError *error)
-         {
-             if( error != nil && [error code]== 410)
-             {
-                 
-                 [self createRegistrationIdAndUpsert:name payload:payload deviceToken:deviceToken completion:completion];
-             }
-             else
-             {
-                 if(completion)
-                 {
-                     completion(error);
-                 }
-             }
-         }];
-    }
-    else
-    {
-        [self upsertRegistrationWithName:name registrationId:cached.RegistrationId payload:payload completion:^(NSError *error)
-        {
-            if( error != nil && [error code]== 410)
-            {
-                
-                [self createRegistrationIdAndUpsert:name payload:payload deviceToken:deviceToken completion:completion];
-            }
-            else
-            {
-                if( completion)
-                {
-                    completion(error);
-                }
-            }
-        }];
-    }
-}
-
-- (void)createRegistrationIdAndUpsert:(NSString*)name payload:(NSString*)payload deviceToken:(NSString*)deviceToken completion:(void (^)(NSError*))completion
-{
-    NSURL *requestUri = [self composeCreateRegistrationIdUri];
-    [self registrationOperationWithRequestUri:requestUri payload:@"" httpMethod:@"POST" ETag:@"" completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
-        if(!error)
-        {
-            NSURL* locationUrl = [[NSURL alloc] initWithString:[[response allHeaderFields] objectForKey:@"Location"]];
-            NSString *registrationId = [self extractRegistrationIdFromLocationUri:locationUrl];
-            [storageManager updateWithRegistrationName:name registrationId:registrationId  eTag:@"*" deviceToken:deviceToken];
-            [self upsertRegistrationWithName:name registrationId:registrationId payload:payload completion:completion];
-        }
-        else
-        {
-            if(completion)
-            {
-                completion(error);
-            }
-        }
-    }];
-}
-
-- (void)upsertRegistrationWithName:(NSString*)name registrationId:(NSString*)registrationId payload:(NSString*)payload completion:(void (^)(NSError*))completion
-{
-    NSURL *requestUri = [self composeRegistrationUriWithRegistrationId: registrationId];
-    [self registrationOperationWithRequestUri:requestUri payload:payload httpMethod:@"PUT" ETag:@"" completion:^(NSHTTPURLResponse *response1, NSData *data, NSError *error) {
-        
-        if(!error)
-        {
-            [self parseResultAndUpdateWithName:name data:data error:&error];
-        }
-        
-        if(completion)
-        {
-            completion(error);
-        }
-    }];
-}
-
-- (void)parseResultAndUpdateWithName:(NSString *)name data:(NSData *)data error:(NSError **)error
-{
-    NSError* parseError;
-    NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&parseError];
-    if( !parseError)
-    {
-        [storageManager updateWithRegistrationName:name registration:(SBRegistration*)[registrations objectAtIndex:0]];
-    }
-    else if( error)
-    {
-        (*error) = parseError;
-    }
-}
-
-- (void) retrieveAllRegistrationsWithDeviceToken:(NSString*)deviceToken completion:(void (^)(NSArray*, NSError*))completion
-{
-    NSURL *requestUri = [self composeRetrieveAllRegistrationsUriWithDeviceToken:deviceToken];
-    [self registrationOperationWithRequestUri:requestUri payload:@"" httpMethod:@"GET" ETag:@"" completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
-        
-        if(error)
-        {
-            if([error code]==404)
-            {
-                if(completion)
-                {
-                    completion(nil,nil);
-                }
-                return;
-            }
-            else
-            {
-                if(completion)
-                {
-                    completion(nil,error);
-                }
-                return;
-            }
-        }
-        
-        NSError *parseError;
-        NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&parseError];
-        if( parseError)
-        {
-            if(completion)
-            {
-                completion(nil,parseError);
-            }
-            
-            return;
-        }
-
-        for (SBRegistration* retrieved in registrations)
-        {
-            [storageManager updateWithRegistration:retrieved];
-        }
-        
-        if(completion)
-        {
-            completion(registrations,nil);
-        }
-    }];
-}
-
-- (void) unregisterNativeWithCompletion:(void (^)(NSError*))completion
-{
-    [self deleteRegistrationWithName:[SBRegistration Name] completion:completion];
-}
-
-- (void) unregisterTemplateWithName:(NSString*)name completion:(void (^)(NSError*))completion
-{
-    NSError* error;
-    if( [self verifyTemplateName:name error:&error] == FALSE)
-    {
-        if(completion)
-        {
-            completion(error);
-        }
-        
-        return;
-    }
-    
-    
-    [self deleteRegistrationWithName:name completion:completion];
-}
-
-- (void) deleteRegistrationWithName:(NSString*)templateName completion:(void (^)(NSError*))completion
-{
-    StoredRegistrationEntry* cached = [storageManager getStoredRegistrationEntryWithRegistrationName:templateName];
-    if(cached == nil)
-    {
-        if(completion)
-        {
-            completion(nil);
-        }
-        
-        return;
-    }
-    
-    NSURL *requestUri = [self composeRegistrationUriWithRegistrationId: cached.RegistrationId];
-    [self registrationOperationWithRequestUri:requestUri payload:@"" httpMethod:@"DELETE" ETag:@"*" completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
-        
-        if( error == nil || [error code] == 404 )
-        {
-            [storageManager deleteWithRegistrationName:templateName];
-            error = nil;
-        }
-        
-        if(completion)
-        {
-            completion(error);
-        }
-    }];
-}
-
-- (void) unregisterAllWithDeviceToken:(NSData*)deviceTokenData completion:(void (^)(NSError*))completion
-{
-    if( deviceTokenData == nil)
-    {
-        if(completion)
-        {
-            completion([SBNotificationHubHelper errorForNullDeviceToken]);
-        }
-        
-        return;
-    }
-    
-    NSString* deviceToken = [self convertDeviceToken:deviceTokenData];
-
-    SBThreadParameter* parameter = [[SBThreadParameter alloc]init];
-    parameter.deviceToken = deviceToken;
-    parameter.completion = completion;
-    parameter.isMainThread = [[NSThread currentThread] isMainThread];
-    [self performSelectorInBackground:@selector(deleteAllRegistrationThread:) withObject:parameter];
-}
-
-- (void) deleteAllRegistrationThread:(SBThreadParameter*)parameter
-{
-    NSError* error;
-    NSArray* registrations = [self retrieveAllRegistrationsWithDeviceToken:parameter.deviceToken error:&error];
-    if(registrations.count != 0)
-    {
-        for(SBRegistration* reg in registrations)
-        {
-            NSString* name = [SBNotificationHubHelper nameOfRegistration:reg];
-            [self deleteRegistrationWithName:name error:&error];
-            if(error)
-            {
-                break;
-            }
-        }
-    }
-    
-    if (!error)
-    {
-        // Remove any registrations that are only in the client and not on server
-        [storageManager deleteAllRegistrations];
-    }
-    
-    if(parameter.completion)
-    {
-        if( parameter.isMainThread)
-        {
-            // callback on main thread
-            dispatch_async(dispatch_get_main_queue(), ^{parameter.completion(error);});
-        }
-        else
-        {
-            parameter.completion(error);
-        }
-    }
-}
-
-- (BOOL) registerNativeWithDeviceToken:(NSData*)deviceTokenData tags:(NSSet*)tags error:(NSError**)error
-{
-    if( deviceTokenData == nil)
-    {
-        if(error)
-        {
-            *error = [SBNotificationHubHelper errorForNullDeviceToken];
-        }
-        
-        return FALSE;
-    }
-    
-    NSString* deviceToken = [self convertDeviceToken:deviceTokenData];
-    
-    NSString* name =[SBRegistration Name];
-    NSString* payload = [SBRegistration payloadWithDeviceToken:deviceToken tags:tags];
-    
-    if( storageManager.isRefreshNeeded)
-    {
-        NSString* refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
-        
-        NSError* retrieveError;
-        [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken error:&retrieveError];
-        
-        if( retrieveError )
-        {
-            if( error)
-            {
-                *error = retrieveError;
-            }
-            
-            return FALSE;
-        }
-        
-        [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
-    }
-    
-    return [self createorUpdateWith:name payload:payload deviceToken:deviceToken error:error];
-}
-
-- (BOOL) registerTemplateWithDeviceToken:(NSData*)deviceTokenData name:(NSString*)templateName jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate tags:(NSSet*)tags error:(NSError**)error
-{
-    return [self registerTemplateWithDeviceToken:deviceTokenData name:templateName jsonBodyTemplate:bodyTemplate expiryTemplate:expiryTemplate priorityTemplate:nil tags:tags error:error];
-}
-
-- (BOOL) registerTemplateWithDeviceToken:(NSData*)deviceTokenData name:(NSString*)templateName jsonBodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate priorityTemplate:(NSString*)priorityTemplate tags:(NSSet*)tags error:(NSError**)error
-{
-    if( deviceTokenData == nil)
-    {
-        if(error)
-        {
-            *error = [SBNotificationHubHelper errorForNullDeviceToken];
-        }
-        
-        return FALSE;
-    }
-    
-    NSString* deviceToken = [self convertDeviceToken:deviceTokenData];
-    
-    if( [self verifyTemplateName:templateName error:error] == FALSE)
-    {
-        return FALSE;
-    }
-    
-    NSString* payload = [SBTemplateRegistration payloadWithDeviceToken:deviceToken bodyTemplate:bodyTemplate expiryTemplate:expiryTemplate priorityTemplate:priorityTemplate tags:tags templateName:templateName];
-    
-    if( storageManager.isRefreshNeeded)
-    {
-        NSString* refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
-        
-        NSError* retrieveError;
-        [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken error:&retrieveError];
-        
-        if( retrieveError )
-        {
-            if( error)
-            {
-                *error = retrieveError;
-            }
-            
-            return FALSE;
-        }
-        
-        [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
-    }
-    
-    return [self createorUpdateWith:templateName payload:payload deviceToken:deviceToken error:error];
-}
-
-- (BOOL)createorUpdateWith:(NSString *)name payload:(NSString *)payload deviceToken:(NSString *)deviceToken error:(NSError**)error
-{
-    StoredRegistrationEntry* cached = [storageManager getStoredRegistrationEntryWithRegistrationName:name];
-    NSString *registrationId;
-    if(cached == nil)
-    {
-        NSError *createRegistrationError;
-        registrationId = [self createRegistrationId:&createRegistrationError];
-        if (createRegistrationError)
-        {
-            if (error)
-            {
-                *error = createRegistrationError;
-            }
-            
-            return false;
-        }
-        
-        [storageManager updateWithRegistrationName:name registrationId:registrationId eTag:@"*" deviceToken:deviceToken];
-    }
-    else
-    {
-        registrationId = cached.RegistrationId;
-    }
-    
-    NSError *upsertRegistrationError;
-    BOOL result = [self upsertRegistrationWithName:name registrationId:registrationId payload:payload error:&upsertRegistrationError];
-    if( upsertRegistrationError != nil && [upsertRegistrationError code] == 410)
-    {
-        // if we get 410 from service, we will recreate registration id and will try to do upsert
-        NSError *retrieveRegistrationError;
-        registrationId = [self createRegistrationId:&retrieveRegistrationError];
-        if (retrieveRegistrationError)
-        {
-            if (error)
-            {
-                *error = retrieveRegistrationError;
-            }
-            
-            return false;
-        }
-        
-        [storageManager updateWithRegistrationName:name registrationId:registrationId eTag:@"*" deviceToken:deviceToken];
-        NSError *operationError;
-        result = [self upsertRegistrationWithName:name registrationId:registrationId payload:payload error:&operationError];
-        if (operationError)
-        {
-            if (error)
-            {
-                *error = operationError;
-            }
-            
-        }
-        
-        return result;
-    }
-    
-    if(error)
-    {
-        (*error) = upsertRegistrationError;
-    }
-    
-    return result;
-}
-
-- (NSString*)createRegistrationId:(NSError**)error
-{
-    NSURL *requestUri = [self composeCreateRegistrationIdUri];
-    NSHTTPURLResponse* response=nil;
-    NSData* data;
-    NSError* operationError;
-    [self registrationOperationWithRequestUri:requestUri payload:@"" httpMethod:@"POST" ETag:@"" response:&response responseData:&data error:&operationError];
-    
-    if(operationError == nil)
-    {
-        NSURL* locationUrl = [[NSURL alloc] initWithString:[[response allHeaderFields] objectForKey:@"Location"]];
-        return [self extractRegistrationIdFromLocationUri:locationUrl];
-    }
-    
-    if(error)
-    {
-        *error = operationError;
-    }
-    
+  if (!connectionString || !notificationHubPath) {
     return nil;
+  }
+
+  if (self) {
+    NSDictionary *connnectionDictionary = [SBNotificationHubHelper parseConnectionString:connectionString];
+
+    NSString *endPoint = [connnectionDictionary objectForKey:@"endpoint"];
+    if (endPoint) {
+      self->_serviceEndPoint = [[NSURL alloc] initWithString:endPoint];
+    }
+
+    if (self->_serviceEndPoint == nil || [self->_serviceEndPoint host] == nil) {
+      NSLog(@"%@", @"Endpoint is missing or not in URL format in connectionString.");
+      return nil;
+    }
+
+    self->_path = notificationHubPath;
+    tokenProvider = [[SBTokenProvider alloc] initWithConnectionDictinary:connnectionDictionary];
+
+    if (tokenProvider == nil) {
+      return nil;
+    }
+
+    storageManager = [[SBLocalStorage alloc] initWithNotificationHubPath:notificationHubPath];
+
+    if (storageManager == nil) {
+      return nil;
+    }
+  }
+
+  return self;
 }
 
-- (BOOL)createRegistrationWithName:(NSString*)name payload:(NSString*)payload error:(NSError**)error
-{
-    NSURL *requestUri = [self composeRegistrationUriWithRegistrationId: @""];
-    
-    NSHTTPURLResponse* response=nil;
-    NSData* data;
-    NSError* operationError;
-    BOOL result = [self registrationOperationWithRequestUri:requestUri payload:payload httpMethod:@"POST" ETag:@"" response:&response responseData:&data error:&operationError];
-    
-    if( operationError == nil)
-    {
-        NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&operationError];
-        if( operationError == nil)
-        {
-            [storageManager updateWithRegistrationName:name registration:(SBRegistration*)[registrations objectAtIndex:0]];
-        }
-    }
-    
-    if(error)
-    {
-        *error = operationError;
-    }
-    
-    return result;
+- (NSString *)convertDeviceToken:(NSData *)deviceTokenData {
+  const char *data = [deviceTokenData bytes];
+  NSMutableString *newDeviceToken = [NSMutableString string];
+
+  for (NSUInteger i = 0; i < [deviceTokenData length]; i++) {
+    [newDeviceToken appendFormat:@"%02.2hhX", data[i]];
+  }
+
+  return [newDeviceToken copy];
 }
 
-- (BOOL)upsertRegistrationWithName:(NSString*)name registrationId:(NSString*)registrationId payload:(NSString*)payload error:(NSError**)error
+- (void)registerNativeWithDeviceToken:(NSData *)deviceTokenData tags:(NSSet *)tags completion:(void (^)(NSError *error))completion;
 {
-    NSURL *requestUri = [self composeRegistrationUriWithRegistrationId: registrationId];
-    
-    NSHTTPURLResponse* response=nil;
-    NSData* data;
-    NSError* operationError;
-    BOOL result = [self registrationOperationWithRequestUri:requestUri payload:payload httpMethod:@"PUT" ETag:@"" response:&response responseData:&data error:&operationError];
-    
-    if( operationError == nil)
-    {
-        NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&operationError];
-        if( operationError == nil)
-        {
-            [storageManager updateWithRegistrationName:name registration:(SBRegistration*)[registrations objectAtIndex:0]];
-        }
+  if (deviceTokenData == nil) {
+    if (completion) {
+      completion([SBNotificationHubHelper errorForNullDeviceToken]);
     }
-    
-    if(error)
-    {
-        *error = operationError;
-    }
-    
-    return result;
+
+    return;
+  }
+
+  NSString *deviceToken = [self convertDeviceToken:deviceTokenData];
+  NSString *name = [SBRegistration Name];
+  NSString *payload = [SBRegistration payloadWithDeviceToken:deviceToken tags:tags];
+
+  if (storageManager.isRefreshNeeded) {
+    NSString *refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
+    [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken
+                                       completion:^(NSArray *regs, NSError *error) {
+                                         if (error == nil) {
+                                           [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
+                                           [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
+                                         } else {
+                                           if (completion) {
+                                             completion(error);
+                                           }
+                                         }
+                                       }];
+  } else {
+    [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
+  }
 }
 
-
-// This function will retrieve all registrations and update local storage with them.
-- (NSArray*) retrieveAllRegistrationsWithDeviceToken:(NSString*)deviceToken error:(NSError**)error
+- (void)registerTemplateWithDeviceToken:(NSData *)deviceTokenData
+                                   name:(NSString *)name
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                                   tags:(NSSet *)tags
+                             completion:(void (^)(NSError *error))completion;
 {
-    NSURL *requestUri = [self composeRetrieveAllRegistrationsUriWithDeviceToken:deviceToken];
-    
-    NSHTTPURLResponse* response=nil;
-    NSData* data;
-    NSError* operationError;
-    [self registrationOperationWithRequestUri:requestUri payload:@"" httpMethod:@"GET" ETag:@"" response:&response responseData:&data error:&operationError];
-    
-    if(operationError)
-    {
-        if([operationError code]==404)
-        {
-            //no registrations
-            return nil;
-        }
-        
-        if( error)
-        {
-            (*error) = operationError;
-        }
-        
-        return nil;
-    }
-    
-    NSError *parseError;
-    NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&parseError];    
-    if(parseError)
-    {
-        if( error)
-        {
-            (*error) = parseError;
-        }
-    }
-    else
-    {
-        [storageManager deleteAllRegistrations];
-        for (SBRegistration* retrieved in registrations)
-        {
-            [storageManager updateWithRegistration:retrieved];
-        }
-    }
-    
-    return registrations;
+  [self registerTemplateWithDeviceToken:deviceTokenData
+                                   name:name
+                       jsonBodyTemplate:bodyTemplate
+                         expiryTemplate:expiryTemplate
+                       priorityTemplate:nil
+                                   tags:tags
+                             completion:completion];
 }
 
-- (BOOL) unregisterNativeWithError:(NSError**)error
+- (void)registerTemplateWithDeviceToken:(NSData *)deviceTokenData
+                                   name:(NSString *)name
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                       priorityTemplate:(NSString *)priorityTemplate
+                                   tags:(NSSet *)tags
+                             completion:(void (^)(NSError *error))completion;
 {
-    return [self deleteRegistrationWithName:[SBRegistration Name] error:error];
+  if (deviceTokenData == nil) {
+    if (completion) {
+      completion([SBNotificationHubHelper errorForNullDeviceToken]);
+    }
+
+    return;
+  }
+
+  NSString *deviceToken = [self convertDeviceToken:deviceTokenData];
+
+  NSError *error;
+  if ([self verifyTemplateName:name error:&error] == FALSE) {
+    if (completion) {
+      completion(error);
+    }
+
+    return;
+  }
+
+  NSString *payload = [SBTemplateRegistration payloadWithDeviceToken:deviceToken
+                                                        bodyTemplate:bodyTemplate
+                                                      expiryTemplate:expiryTemplate
+                                                    priorityTemplate:priorityTemplate
+                                                                tags:tags
+                                                        templateName:name];
+
+  if (storageManager.isRefreshNeeded) {
+    NSString *refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
+    [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken
+                                       completion:^(NSArray *regs, NSError *error) {
+                                         if (error == nil) {
+                                           [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
+                                           [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
+                                         } else {
+                                           if (completion) {
+                                             completion(error);
+                                           }
+                                         }
+                                       }];
+  } else {
+    [self createOrUpdateWith:name payload:payload deviceToken:deviceToken completion:completion];
+  }
 }
 
-- (BOOL) unregisterTemplateWithName:(NSString*)name error:(NSError**)error
-{
-    if( [self verifyTemplateName:name error:error] == FALSE)
-    {
-        return FALSE;
-    }
-    
-    return [self deleteRegistrationWithName:name error:error];
+- (void)createOrUpdateWith:(NSString *)name
+                   payload:(NSString *)payload
+               deviceToken:(NSString *)deviceToken
+                completion:(void (^)(NSError *))completion {
+  StoredRegistrationEntry *cached = [storageManager getStoredRegistrationEntryWithRegistrationName:name];
+  if (cached == nil) {
+    [self createRegistrationIdAndUpsert:name
+                                payload:payload
+                            deviceToken:deviceToken
+                             completion:^(NSError *error) {
+                               if (error != nil && [error code] == 410) {
+
+                                 [self createRegistrationIdAndUpsert:name payload:payload deviceToken:deviceToken completion:completion];
+                               } else {
+                                 if (completion) {
+                                   completion(error);
+                                 }
+                               }
+                             }];
+  } else {
+    [self upsertRegistrationWithName:name
+                      registrationId:cached.RegistrationId
+                             payload:payload
+                          completion:^(NSError *error) {
+                            if (error != nil && [error code] == 410) {
+
+                              [self createRegistrationIdAndUpsert:name payload:payload deviceToken:deviceToken completion:completion];
+                            } else {
+                              if (completion) {
+                                completion(error);
+                              }
+                            }
+                          }];
+  }
 }
 
-- (BOOL) deleteRegistrationWithName:(NSString*)name error:(NSError**)error
-{
-    StoredRegistrationEntry* cached = [storageManager getStoredRegistrationEntryWithRegistrationName:name];
-    if(cached == nil)
-    {   
-        return true;
-    }
-    
-    NSURL *requestUri = [self composeRegistrationUriWithRegistrationId: cached.RegistrationId];
-    
-    NSURLResponse* response=nil;
-    NSData* data;
-    NSError* operationError;
-    BOOL result = [self registrationOperationWithRequestUri:requestUri payload:@"" httpMethod:@"DELETE" ETag:@"*" response:&response responseData:&data error:&operationError];
-    
-    if( operationError == nil || [operationError code] == 404 )
-    {
-        // don't return error for not-found
-        [storageManager deleteWithRegistrationName:name];
-        error = nil;
-    }
-    
-    if(error != nil)
-    {
-        *error = operationError;
-    }
-    
-    return result;
+- (void)createRegistrationIdAndUpsert:(NSString *)name
+                              payload:(NSString *)payload
+                          deviceToken:(NSString *)deviceToken
+                           completion:(void (^)(NSError *))completion {
+  NSURL *requestUri = [self composeCreateRegistrationIdUri];
+  [self registrationOperationWithRequestUri:requestUri
+                                    payload:@""
+                                 httpMethod:@"POST"
+                                       ETag:@""
+                                 completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+                                   if (!error) {
+                                     NSURL *locationUrl =
+                                         [[NSURL alloc] initWithString:[[response allHeaderFields] objectForKey:@"Location"]];
+                                     NSString *registrationId = [self extractRegistrationIdFromLocationUri:locationUrl];
+                                     [storageManager updateWithRegistrationName:name
+                                                                 registrationId:registrationId
+                                                                           eTag:@"*"
+                                                                    deviceToken:deviceToken];
+                                     [self upsertRegistrationWithName:name
+                                                       registrationId:registrationId
+                                                              payload:payload
+                                                           completion:completion];
+                                   } else {
+                                     if (completion) {
+                                       completion(error);
+                                     }
+                                   }
+                                 }];
 }
 
-- (BOOL) unregisterAllWithDeviceToken:(NSData*)deviceTokenData error:(NSError**)error
-{
-    if( deviceTokenData == nil)
-    {
-        if(error)
-        {
-            *error = [SBNotificationHubHelper errorForNullDeviceToken];
-        }
-        
-        return FALSE;
+- (void)upsertRegistrationWithName:(NSString *)name
+                    registrationId:(NSString *)registrationId
+                           payload:(NSString *)payload
+                        completion:(void (^)(NSError *))completion {
+  NSURL *requestUri = [self composeRegistrationUriWithRegistrationId:registrationId];
+  [self registrationOperationWithRequestUri:requestUri
+                                    payload:payload
+                                 httpMethod:@"PUT"
+                                       ETag:@""
+                                 completion:^(NSHTTPURLResponse *response1, NSData *data, NSError *error) {
+                                   if (!error) {
+                                     [self parseResultAndUpdateWithName:name data:data error:&error];
+                                   }
+
+                                   if (completion) {
+                                     completion(error);
+                                   }
+                                 }];
+}
+
+- (void)parseResultAndUpdateWithName:(NSString *)name data:(NSData *)data error:(NSError **)error {
+  NSError *parseError;
+  NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&parseError];
+  if (!parseError) {
+    [storageManager updateWithRegistrationName:name registration:(SBRegistration *)[registrations objectAtIndex:0]];
+  } else if (error) {
+    (*error) = parseError;
+  }
+}
+
+- (void)retrieveAllRegistrationsWithDeviceToken:(NSString *)deviceToken completion:(void (^)(NSArray *, NSError *))completion {
+  NSURL *requestUri = [self composeRetrieveAllRegistrationsUriWithDeviceToken:deviceToken];
+  [self registrationOperationWithRequestUri:requestUri
+                                    payload:@""
+                                 httpMethod:@"GET"
+                                       ETag:@""
+                                 completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+                                   if (error) {
+                                     if ([error code] == 404) {
+                                       if (completion) {
+                                         completion(nil, nil);
+                                       }
+                                       return;
+                                     } else {
+                                       if (completion) {
+                                         completion(nil, error);
+                                       }
+                                       return;
+                                     }
+                                   }
+
+                                   NSError *parseError;
+                                   NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&parseError];
+                                   if (parseError) {
+                                     if (completion) {
+                                       completion(nil, parseError);
+                                     }
+
+                                     return;
+                                   }
+
+                                   for (SBRegistration *retrieved in registrations) {
+                                     [storageManager updateWithRegistration:retrieved];
+                                   }
+
+                                   if (completion) {
+                                     completion(registrations, nil);
+                                   }
+                                 }];
+}
+
+- (void)unregisterNativeWithCompletion:(void (^)(NSError *))completion {
+  [self deleteRegistrationWithName:[SBRegistration Name] completion:completion];
+}
+
+- (void)unregisterTemplateWithName:(NSString *)name completion:(void (^)(NSError *))completion {
+  NSError *error;
+  if ([self verifyTemplateName:name error:&error] == FALSE) {
+    if (completion) {
+      completion(error);
     }
-    
-    NSString* deviceToken = [self convertDeviceToken:deviceTokenData];
-    
-    NSError* operationError;
-    NSArray* registrations = [self retrieveAllRegistrationsWithDeviceToken:deviceToken error:&operationError];
-    
-    if( operationError )
-    {
-        if(error)
-        {
-            *error = operationError;
-        }
-        
-        return FALSE;
+
+    return;
+  }
+
+  [self deleteRegistrationWithName:name completion:completion];
+}
+
+- (void)deleteRegistrationWithName:(NSString *)templateName completion:(void (^)(NSError *))completion {
+  StoredRegistrationEntry *cached = [storageManager getStoredRegistrationEntryWithRegistrationName:templateName];
+  if (cached == nil) {
+    if (completion) {
+      completion(nil);
     }
-    
-    for (SBRegistration* reg in registrations) {
-        NSString* name = [SBNotificationHubHelper nameOfRegistration:reg];
-        [self deleteRegistrationWithName:name error:&operationError];
-        if(operationError)
-        {
-            if(error)
-            {
-                *error = operationError;
-            }
-            
-            return FALSE;
-        }
+
+    return;
+  }
+
+  NSURL *requestUri = [self composeRegistrationUriWithRegistrationId:cached.RegistrationId];
+  [self registrationOperationWithRequestUri:requestUri
+                                    payload:@""
+                                 httpMethod:@"DELETE"
+                                       ETag:@"*"
+                                 completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+                                   if (error == nil || [error code] == 404) {
+                                     [storageManager deleteWithRegistrationName:templateName];
+                                     error = nil;
+                                   }
+
+                                   if (completion) {
+                                     completion(error);
+                                   }
+                                 }];
+}
+
+- (void)unregisterAllWithDeviceToken:(NSData *)deviceTokenData completion:(void (^)(NSError *))completion {
+  if (deviceTokenData == nil) {
+    if (completion) {
+      completion([SBNotificationHubHelper errorForNullDeviceToken]);
     }
-    
+
+    return;
+  }
+
+  NSString *deviceToken = [self convertDeviceToken:deviceTokenData];
+
+  SBThreadParameter *parameter = [[SBThreadParameter alloc] init];
+  parameter.deviceToken = deviceToken;
+  parameter.completion = completion;
+  parameter.isMainThread = [[NSThread currentThread] isMainThread];
+  [self performSelectorInBackground:@selector(deleteAllRegistrationThread:) withObject:parameter];
+}
+
+- (void)deleteAllRegistrationThread:(SBThreadParameter *)parameter {
+  NSError *error;
+  NSArray *registrations = [self retrieveAllRegistrationsWithDeviceToken:parameter.deviceToken error:&error];
+  if (registrations.count != 0) {
+    for (SBRegistration *reg in registrations) {
+      NSString *name = [SBNotificationHubHelper nameOfRegistration:reg];
+      [self deleteRegistrationWithName:name error:&error];
+      if (error) {
+        break;
+      }
+    }
+  }
+
+  if (!error) {
     // Remove any registrations that are only in the client and not on server
     [storageManager deleteAllRegistrations];
-    
-    return TRUE;
-}
+  }
 
-- (BOOL) verifyTemplateName:(NSString*)name error:(NSError**)error
-{
-     if( [name isEqualToString: [SBRegistration Name]])
-     {
-         if(error)
-         {
-             *error = [SBNotificationHubHelper errorForReservedTemplateName];
-         }
-         
-         return FALSE;
-     }
-    
-    NSRange range = [name rangeOfString:@":"];
-    if (range.length > 0)
-    {
-        if(error)
-        {
-            *error = [SBNotificationHubHelper errorForInvalidTemplateName];
-        }
+  if (parameter.completion) {
+    if (parameter.isMainThread) {
+      // callback on main thread
+      dispatch_async(dispatch_get_main_queue(), ^{
+        parameter.completion(error);
+      });
+    } else {
+      parameter.completion(error);
     }
-    
-    return TRUE;
+  }
 }
 
-- (void) registrationOperationWithRequestUri:(NSURL*)requestUri payload:(NSString*)payload httpMethod:(NSString*) httpMethod ETag:(NSString*)etag completion:(void (^)(NSHTTPURLResponse *response, NSData *data, NSError *error))completion
-{
-    NSMutableURLRequest *theRequest = [self PrepareUrlRequest:requestUri httpMethod:httpMethod ETag:etag payload:payload];
-    
-    [tokenProvider setTokenWithRequest:theRequest completion:^(NSError *error) {
-        if(error)
-        {
-            if(completion)
-            {
-                completion(nil,nil,error);
-            }
-            
-            return;
-        }
-        
-        [[[SBURLConnection alloc] init] sendRequest:theRequest completion:completion];
-    } ];
-}
-
-- (BOOL) registrationOperationWithRequestUri:(NSURL*)requestUri payload:(NSString*)payload httpMethod:(NSString*) httpMethod ETag:(NSString*)etag response:(NSHTTPURLResponse**)response responseData:(NSData**)responseData error:(NSError**)error
-{
-    NSMutableURLRequest *theRequest = [self PrepareUrlRequest:requestUri httpMethod:httpMethod ETag:etag payload:payload];
-    
-    [tokenProvider setTokenWithRequest:theRequest error:error];
-    if(*error != nil)
-    {
-        return FALSE;
+- (BOOL)registerNativeWithDeviceToken:(NSData *)deviceTokenData tags:(NSSet *)tags error:(NSError **)error {
+  if (deviceTokenData == nil) {
+    if (error) {
+      *error = [SBNotificationHubHelper errorForNullDeviceToken];
     }
-    
-    //send synchronously
-    (*responseData) = [[[SBURLConnection alloc] init] sendSynchronousRequest:theRequest returningResponse:response error:error];
-    
-    if(*error != nil)
-    {
+
+    return FALSE;
+  }
+
+  NSString *deviceToken = [self convertDeviceToken:deviceTokenData];
+
+  NSString *name = [SBRegistration Name];
+  NSString *payload = [SBRegistration payloadWithDeviceToken:deviceToken tags:tags];
+
+  if (storageManager.isRefreshNeeded) {
+    NSString *refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
+
+    NSError *retrieveError;
+    [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken error:&retrieveError];
+
+    if (retrieveError) {
+      if (error) {
+        *error = retrieveError;
+      }
+
+      return FALSE;
+    }
+
+    [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
+  }
+
+  return [self createorUpdateWith:name payload:payload deviceToken:deviceToken error:error];
+}
+
+- (BOOL)registerTemplateWithDeviceToken:(NSData *)deviceTokenData
+                                   name:(NSString *)templateName
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                                   tags:(NSSet *)tags
+                                  error:(NSError **)error {
+  return [self registerTemplateWithDeviceToken:deviceTokenData
+                                          name:templateName
+                              jsonBodyTemplate:bodyTemplate
+                                expiryTemplate:expiryTemplate
+                              priorityTemplate:nil
+                                          tags:tags
+                                         error:error];
+}
+
+- (BOOL)registerTemplateWithDeviceToken:(NSData *)deviceTokenData
+                                   name:(NSString *)templateName
+                       jsonBodyTemplate:(NSString *)bodyTemplate
+                         expiryTemplate:(NSString *)expiryTemplate
+                       priorityTemplate:(NSString *)priorityTemplate
+                                   tags:(NSSet *)tags
+                                  error:(NSError **)error {
+  if (deviceTokenData == nil) {
+    if (error) {
+      *error = [SBNotificationHubHelper errorForNullDeviceToken];
+    }
+
+    return FALSE;
+  }
+
+  NSString *deviceToken = [self convertDeviceToken:deviceTokenData];
+
+  if ([self verifyTemplateName:templateName error:error] == FALSE) {
+    return FALSE;
+  }
+
+  NSString *payload = [SBTemplateRegistration payloadWithDeviceToken:deviceToken
+                                                        bodyTemplate:bodyTemplate
+                                                      expiryTemplate:expiryTemplate
+                                                    priorityTemplate:priorityTemplate
+                                                                tags:tags
+                                                        templateName:templateName];
+
+  if (storageManager.isRefreshNeeded) {
+    NSString *refreshDeviceToken = [self getRefreshDeviceTokenWithNewDeviceToken:deviceToken];
+
+    NSError *retrieveError;
+    [self retrieveAllRegistrationsWithDeviceToken:refreshDeviceToken error:&retrieveError];
+
+    if (retrieveError) {
+      if (error) {
+        *error = retrieveError;
+      }
+
+      return FALSE;
+    }
+
+    [storageManager refreshFinishedWithDeviceToken:refreshDeviceToken];
+  }
+
+  return [self createorUpdateWith:templateName payload:payload deviceToken:deviceToken error:error];
+}
+
+- (BOOL)createorUpdateWith:(NSString *)name payload:(NSString *)payload deviceToken:(NSString *)deviceToken error:(NSError **)error {
+  StoredRegistrationEntry *cached = [storageManager getStoredRegistrationEntryWithRegistrationName:name];
+  NSString *registrationId;
+  if (cached == nil) {
+    NSError *createRegistrationError;
+    registrationId = [self createRegistrationId:&createRegistrationError];
+    if (createRegistrationError) {
+      if (error) {
+        *error = createRegistrationError;
+      }
+
+      return false;
+    }
+
+    [storageManager updateWithRegistrationName:name registrationId:registrationId eTag:@"*" deviceToken:deviceToken];
+  } else {
+    registrationId = cached.RegistrationId;
+  }
+
+  NSError *upsertRegistrationError;
+  BOOL result = [self upsertRegistrationWithName:name registrationId:registrationId payload:payload error:&upsertRegistrationError];
+  if (upsertRegistrationError != nil && [upsertRegistrationError code] == 410) {
+    // if we get 410 from service, we will recreate registration id and will try
+    // to do upsert
+    NSError *retrieveRegistrationError;
+    registrationId = [self createRegistrationId:&retrieveRegistrationError];
+    if (retrieveRegistrationError) {
+      if (error) {
+        *error = retrieveRegistrationError;
+      }
+
+      return false;
+    }
+
+    [storageManager updateWithRegistrationName:name registrationId:registrationId eTag:@"*" deviceToken:deviceToken];
+    NSError *operationError;
+    result = [self upsertRegistrationWithName:name registrationId:registrationId payload:payload error:&operationError];
+    if (operationError) {
+      if (error) {
+        *error = operationError;
+      }
+    }
+
+    return result;
+  }
+
+  if (error) {
+    (*error) = upsertRegistrationError;
+  }
+
+  return result;
+}
+
+- (NSString *)createRegistrationId:(NSError **)error {
+  NSURL *requestUri = [self composeCreateRegistrationIdUri];
+  NSHTTPURLResponse *response = nil;
+  NSData *data;
+  NSError *operationError;
+  [self registrationOperationWithRequestUri:requestUri
+                                    payload:@""
+                                 httpMethod:@"POST"
+                                       ETag:@""
+                                   response:&response
+                               responseData:&data
+                                      error:&operationError];
+
+  if (operationError == nil) {
+    NSURL *locationUrl = [[NSURL alloc] initWithString:[[response allHeaderFields] objectForKey:@"Location"]];
+    return [self extractRegistrationIdFromLocationUri:locationUrl];
+  }
+
+  if (error) {
+    *error = operationError;
+  }
+
+  return nil;
+}
+
+- (BOOL)createRegistrationWithName:(NSString *)name payload:(NSString *)payload error:(NSError **)error {
+  NSURL *requestUri = [self composeRegistrationUriWithRegistrationId:@""];
+
+  NSHTTPURLResponse *response = nil;
+  NSData *data;
+  NSError *operationError;
+  BOOL result = [self registrationOperationWithRequestUri:requestUri
+                                                  payload:payload
+                                               httpMethod:@"POST"
+                                                     ETag:@""
+                                                 response:&response
+                                             responseData:&data
+                                                    error:&operationError];
+
+  if (operationError == nil) {
+    NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&operationError];
+    if (operationError == nil) {
+      [storageManager updateWithRegistrationName:name registration:(SBRegistration *)[registrations objectAtIndex:0]];
+    }
+  }
+
+  if (error) {
+    *error = operationError;
+  }
+
+  return result;
+}
+
+- (BOOL)upsertRegistrationWithName:(NSString *)name
+                    registrationId:(NSString *)registrationId
+                           payload:(NSString *)payload
+                             error:(NSError **)error {
+  NSURL *requestUri = [self composeRegistrationUriWithRegistrationId:registrationId];
+
+  NSHTTPURLResponse *response = nil;
+  NSData *data;
+  NSError *operationError;
+  BOOL result = [self registrationOperationWithRequestUri:requestUri
+                                                  payload:payload
+                                               httpMethod:@"PUT"
+                                                     ETag:@""
+                                                 response:&response
+                                             responseData:&data
+                                                    error:&operationError];
+
+  if (operationError == nil) {
+    NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&operationError];
+    if (operationError == nil) {
+      [storageManager updateWithRegistrationName:name registration:(SBRegistration *)[registrations objectAtIndex:0]];
+    }
+  }
+
+  if (error) {
+    *error = operationError;
+  }
+
+  return result;
+}
+
+// This function will retrieve all registrations and update local storage with
+// them.
+- (NSArray *)retrieveAllRegistrationsWithDeviceToken:(NSString *)deviceToken error:(NSError **)error {
+  NSURL *requestUri = [self composeRetrieveAllRegistrationsUriWithDeviceToken:deviceToken];
+
+  NSHTTPURLResponse *response = nil;
+  NSData *data;
+  NSError *operationError;
+  [self registrationOperationWithRequestUri:requestUri
+                                    payload:@""
+                                 httpMethod:@"GET"
+                                       ETag:@""
+                                   response:&response
+                               responseData:&data
+                                      error:&operationError];
+
+  if (operationError) {
+    if ([operationError code] == 404) {
+      // no registrations
+      return nil;
+    }
+
+    if (error) {
+      (*error) = operationError;
+    }
+
+    return nil;
+  }
+
+  NSError *parseError;
+  NSArray *registrations = [SBRegistrationParser parseRegistrations:data error:&parseError];
+  if (parseError) {
+    if (error) {
+      (*error) = parseError;
+    }
+  } else {
+    [storageManager deleteAllRegistrations];
+    for (SBRegistration *retrieved in registrations) {
+      [storageManager updateWithRegistration:retrieved];
+    }
+  }
+
+  return registrations;
+}
+
+- (BOOL)unregisterNativeWithError:(NSError **)error {
+  return [self deleteRegistrationWithName:[SBRegistration Name] error:error];
+}
+
+- (BOOL)unregisterTemplateWithName:(NSString *)name error:(NSError **)error {
+  if ([self verifyTemplateName:name error:error] == FALSE) {
+    return FALSE;
+  }
+
+  return [self deleteRegistrationWithName:name error:error];
+}
+
+- (BOOL)deleteRegistrationWithName:(NSString *)name error:(NSError **)error {
+  StoredRegistrationEntry *cached = [storageManager getStoredRegistrationEntryWithRegistrationName:name];
+  if (cached == nil) {
+    return true;
+  }
+
+  NSURL *requestUri = [self composeRegistrationUriWithRegistrationId:cached.RegistrationId];
+
+  NSURLResponse *response = nil;
+  NSData *data;
+  NSError *operationError;
+  BOOL result = [self registrationOperationWithRequestUri:requestUri
+                                                  payload:@""
+                                               httpMethod:@"DELETE"
+                                                     ETag:@"*"
+                                                 response:&response
+                                             responseData:&data
+                                                    error:&operationError];
+
+  if (operationError == nil || [operationError code] == 404) {
+    // don't return error for not-found
+    [storageManager deleteWithRegistrationName:name];
+    error = nil;
+  }
+
+  if (error != nil) {
+    *error = operationError;
+  }
+
+  return result;
+}
+
+- (BOOL)unregisterAllWithDeviceToken:(NSData *)deviceTokenData error:(NSError **)error {
+  if (deviceTokenData == nil) {
+    if (error) {
+      *error = [SBNotificationHubHelper errorForNullDeviceToken];
+    }
+
+    return FALSE;
+  }
+
+  NSString *deviceToken = [self convertDeviceToken:deviceTokenData];
+
+  NSError *operationError;
+  NSArray *registrations = [self retrieveAllRegistrationsWithDeviceToken:deviceToken error:&operationError];
+
+  if (operationError) {
+    if (error) {
+      *error = operationError;
+    }
+
+    return FALSE;
+  }
+
+  for (SBRegistration *reg in registrations) {
+    NSString *name = [SBNotificationHubHelper nameOfRegistration:reg];
+    [self deleteRegistrationWithName:name error:&operationError];
+    if (operationError) {
+      if (error) {
+        *error = operationError;
+      }
+
+      return FALSE;
+    }
+  }
+
+  // Remove any registrations that are only in the client and not on server
+  [storageManager deleteAllRegistrations];
+
+  return TRUE;
+}
+
+- (BOOL)verifyTemplateName:(NSString *)name error:(NSError **)error {
+  if ([name isEqualToString:[SBRegistration Name]]) {
+    if (error) {
+      *error = [SBNotificationHubHelper errorForReservedTemplateName];
+    }
+
+    return FALSE;
+  }
+
+  NSRange range = [name rangeOfString:@":"];
+  if (range.length > 0) {
+    if (error) {
+      *error = [SBNotificationHubHelper errorForInvalidTemplateName];
+    }
+  }
+
+  return TRUE;
+}
+
+- (void)registrationOperationWithRequestUri:(NSURL *)requestUri
+                                    payload:(NSString *)payload
+                                 httpMethod:(NSString *)httpMethod
+                                       ETag:(NSString *)etag
+                                 completion:(void (^)(NSHTTPURLResponse *response, NSData *data, NSError *error))completion {
+  NSMutableURLRequest *theRequest = [self PrepareUrlRequest:requestUri httpMethod:httpMethod ETag:etag payload:payload];
+
+  [tokenProvider setTokenWithRequest:theRequest
+                          completion:^(NSError *error) {
+                            if (error) {
+                              if (completion) {
+                                completion(nil, nil, error);
+                              }
+
+                              return;
+                            }
+
+                            [[[SBURLConnection alloc] init] sendRequest:theRequest completion:completion];
+                          }];
+}
+
+- (BOOL)registrationOperationWithRequestUri:(NSURL *)requestUri
+                                    payload:(NSString *)payload
+                                 httpMethod:(NSString *)httpMethod
+                                       ETag:(NSString *)etag
+                                   response:(NSHTTPURLResponse **)response
+                               responseData:(NSData **)responseData
+                                      error:(NSError **)error {
+  NSMutableURLRequest *theRequest = [self PrepareUrlRequest:requestUri httpMethod:httpMethod ETag:etag payload:payload];
+
+  [tokenProvider setTokenWithRequest:theRequest error:error];
+  if (*error != nil) {
+    return FALSE;
+  }
+
+  // send synchronously
+  (*responseData) = [[[SBURLConnection alloc] init] sendSynchronousRequest:theRequest returningResponse:response error:error];
+
+  if (*error != nil) {
+    NSLog(@"Fail to perform registration operation.");
+    NSLog(@"%@", [theRequest description]);
+    NSLog(@"Headers:%@", [theRequest allHTTPHeaderFields]);
+    NSLog(@"Error Response:%@", [[NSString alloc] initWithData:(*responseData) encoding:NSUTF8StringEncoding]);
+
+    return FALSE;
+  } else {
+    NSInteger statusCode = [(*response) statusCode];
+    if (statusCode != 200 && statusCode != 201) {
+      NSString *responseString = [[NSString alloc] initWithData:(*responseData) encoding:NSUTF8StringEncoding];
+
+      if (statusCode != 404) {
         NSLog(@"Fail to perform registration operation.");
-        NSLog(@"%@",[theRequest description]);
-        NSLog(@"Headers:%@",[theRequest allHTTPHeaderFields]);
-        NSLog(@"Error Response:%@",[[NSString alloc]initWithData:(*responseData) encoding:NSUTF8StringEncoding]);
-        
-        return FALSE;
+        NSLog(@"%@", [theRequest description]);
+        NSLog(@"Headers:%@", [theRequest allHTTPHeaderFields]);
+        NSLog(@"Error Response:%@", responseString);
+      }
+
+      if (error) {
+        NSString *msg = [NSString stringWithFormat:@"Fail to perform registration operation. Response:%@", responseString];
+
+        (*error) = [SBNotificationHubHelper errorWithMsg:msg code:statusCode];
+      }
+
+      return FALSE;
     }
-    else
-    {
-        NSInteger statusCode = [(*response) statusCode];
-        if( statusCode != 200 && statusCode != 201)
-        {
-            NSString* responseString = [[NSString alloc]initWithData:(*responseData) encoding:NSUTF8StringEncoding];
-            
-            if(statusCode != 404)
-            {
-                NSLog(@"Fail to perform registration operation.");
-                NSLog(@"%@",[theRequest description]);
-                NSLog(@"Headers:%@",[theRequest allHTTPHeaderFields]);
-                NSLog(@"Error Response:%@",responseString);
-            }
-          
-            if(error)
-            {
-                NSString* msg = [NSString stringWithFormat:@"Fail to perform registration operation. Response:%@",responseString];
-                
-                (*error) = [SBNotificationHubHelper errorWithMsg:msg code:statusCode];
-            }
-             
-            return FALSE;
-        }
-    }
-    
-    return TRUE;
+  }
+
+  return TRUE;
 }
 
-- (NSURL*) composeRetrieveAllRegistrationsUriWithDeviceToken:(NSString*)deviceToken
-{
-    NSString* fullPath = [NSString stringWithFormat:@"%@%@/Registrations/?$filter=deviceToken+eq+'%@'&api-version=%@", [self->_serviceEndPoint absoluteString],self->_path, deviceToken, _APIVersion];
-    
-    return[[NSURL alloc] initWithString: fullPath];
+- (NSURL *)composeRetrieveAllRegistrationsUriWithDeviceToken:(NSString *)deviceToken {
+  NSString *fullPath = [NSString stringWithFormat:@"%@%@/Registrations/?$filter=deviceToken+eq+'%@'&api-version=%@",
+                                                  [self->_serviceEndPoint absoluteString], self -> _path, deviceToken, _APIVersion];
+
+  return [[NSURL alloc] initWithString:fullPath];
 }
 
-- (NSURL*) composeRegistrationUriWithRegistrationId:(NSString*)registrationId
-{
-    if( registrationId == nil)
-    {
-        registrationId = @"";
-    }
-    
-    NSString* fullPath = [NSString stringWithFormat:@"%@%@/Registrations/%@?api-version=%@", [self->_serviceEndPoint absoluteString],self->_path, registrationId, _APIVersion];
-   
-    return[[NSURL alloc] initWithString: fullPath];
+- (NSURL *)composeRegistrationUriWithRegistrationId:(NSString *)registrationId {
+  if (registrationId == nil) {
+    registrationId = @"";
+  }
+
+  NSString *fullPath = [NSString stringWithFormat:@"%@%@/Registrations/%@?api-version=%@", [self->_serviceEndPoint absoluteString],
+                                                  self -> _path, registrationId, _APIVersion];
+
+  return [[NSURL alloc] initWithString:fullPath];
 }
 
-- (NSURL*) composeCreateRegistrationIdUri
-{
-    NSString* fullPath = [NSString stringWithFormat:@"%@%@/registrationids/?api-version=%@", [self->_serviceEndPoint absoluteString],self->_path, _APIVersion];
-    
-    return[[NSURL alloc] initWithString: fullPath];
+- (NSURL *)composeCreateRegistrationIdUri {
+  NSString *fullPath = [NSString
+      stringWithFormat:@"%@%@/registrationids/?api-version=%@", [self->_serviceEndPoint absoluteString], self -> _path, _APIVersion];
+
+  return [[NSURL alloc] initWithString:fullPath];
 }
 
-- (NSMutableURLRequest *)PrepareUrlRequest:(NSURL *)uri httpMethod:(NSString *)httpMethod ETag:(NSString*)etag payload:(NSString *)payload {
-    NSMutableURLRequest *theRequest;
-    theRequest = [NSMutableURLRequest requestWithURL:uri
-                                         cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
-                                     timeoutInterval:60.0];
-    [theRequest setHTTPMethod:httpMethod];
-    
-    if( [payload hasPrefix:@"{"])
-    {
-        [theRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];   
+- (NSMutableURLRequest *)PrepareUrlRequest:(NSURL *)uri
+                                httpMethod:(NSString *)httpMethod
+                                      ETag:(NSString *)etag
+                                   payload:(NSString *)payload {
+  NSMutableURLRequest *theRequest;
+  theRequest = [NSMutableURLRequest requestWithURL:uri cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60.0];
+  [theRequest setHTTPMethod:httpMethod];
+
+  if ([payload hasPrefix:@"{"]) {
+    [theRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+  } else {
+    [theRequest setValue:@"application/xml" forHTTPHeaderField:@"Content-Type"];
+  }
+
+  if (etag != nil && [etag length] > 0) {
+    if (![etag isEqualToString:@"*"]) {
+      etag = [NSString stringWithFormat:@"\"%@\"", etag];
     }
-    else
-    {
-        [theRequest setValue:@"application/xml" forHTTPHeaderField:@"Content-Type"];
-    }
-    
-    if( etag != nil && [etag length]>0)
-    {
-        if( ![etag isEqualToString:@"*"])
-        {
-            etag = [NSString stringWithFormat:@"\"%@\"",etag];
-        }
-        
-        [theRequest addValue: etag forHTTPHeaderField: @"If-Match"];
-    }
-    
-    if( [payload length]>0){
-        NSString* requestBody = [NSString stringWithFormat:@"%@",payload];
-        [theRequest setHTTPBody:[requestBody dataUsingEncoding:NSUTF8StringEncoding]];
-    }
-    
-	
-	NSString *userAgent = [NSString stringWithFormat: _UserAgentTemplate, _APIVersion, [[UIDevice currentDevice] systemName], [[UIDevice currentDevice] systemVersion]];
-	[theRequest addValue:userAgent forHTTPHeaderField:@"User-Agent"];
-	
-    return theRequest;
+
+    [theRequest addValue:etag forHTTPHeaderField:@"If-Match"];
+  }
+
+  if ([payload length] > 0) {
+    NSString *requestBody = [NSString stringWithFormat:@"%@", payload];
+    [theRequest setHTTPBody:[requestBody dataUsingEncoding:NSUTF8StringEncoding]];
+  }
+
+  NSString *userAgent = [NSString
+      stringWithFormat:_UserAgentTemplate, _APIVersion, [[UIDevice currentDevice] systemName], [[UIDevice currentDevice] systemVersion]];
+  [theRequest addValue:userAgent forHTTPHeaderField:@"User-Agent"];
+
+  return theRequest;
 }
 
 // if there is deviceToken from localstorage, we should use it.
-- (NSString*) getRefreshDeviceTokenWithNewDeviceToken:(NSString*)newDeviceToken
-{
-    NSString* deviceToken = [storageManager deviceToken];
-    if( deviceToken == nil || [deviceToken length]==0 )
-    {
-        return newDeviceToken;
-    }
-    else
-    {
-        return deviceToken;
-    }
+- (NSString *)getRefreshDeviceTokenWithNewDeviceToken:(NSString *)newDeviceToken {
+  NSString *deviceToken = [storageManager deviceToken];
+  if (deviceToken == nil || [deviceToken length] == 0) {
+    return newDeviceToken;
+  } else {
+    return deviceToken;
+  }
 }
 
-+ (NSString*) version
-{
-    return currentVersion;
++ (NSString *)version {
+  return currentVersion;
 }
 
--(NSString*) extractRegistrationIdFromLocationUri:(NSURL*) locationUrl
-{
-    NSMutableCharacterSet *trimCharacterSet = [NSMutableCharacterSet whitespaceAndNewlineCharacterSet];
-    [trimCharacterSet addCharactersInString:@"/"];
-    NSString *regisrationIdPath = [locationUrl.path stringByTrimmingCharactersInSet:trimCharacterSet];
-    NSRange lastIndex = [regisrationIdPath rangeOfString:@"/" options:NSBackwardsSearch];
-    NSString *registrationId = [regisrationIdPath substringFromIndex:lastIndex.location+1];
-    
-    return registrationId;
+- (NSString *)extractRegistrationIdFromLocationUri:(NSURL *)locationUrl {
+  NSMutableCharacterSet *trimCharacterSet = [NSMutableCharacterSet whitespaceAndNewlineCharacterSet];
+  [trimCharacterSet addCharactersInString:@"/"];
+  NSString *regisrationIdPath = [locationUrl.path stringByTrimmingCharactersInSet:trimCharacterSet];
+  NSRange lastIndex = [regisrationIdPath rangeOfString:@"/" options:NSBackwardsSearch];
+  NSString *registrationId = [regisrationIdPath substringFromIndex:lastIndex.location + 1];
+
+  return registrationId;
 }
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBRegistration.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBRegistration.h
@@ -6,17 +6,14 @@
 
 @interface SBRegistration : NSObject
 
-@property (copy, nonatomic) NSString* ETag;
-@property (copy, nonatomic) NSDate* expiresAt;
-@property (copy, nonatomic) NSSet* tags;
-@property (copy, nonatomic) NSString* registrationId;
-@property (copy, nonatomic) NSString* deviceToken;
+@property(copy, nonatomic) NSString *ETag;
+@property(copy, nonatomic) NSDate *expiresAt;
+@property(copy, nonatomic) NSSet *tags;
+@property(copy, nonatomic) NSString *registrationId;
+@property(copy, nonatomic) NSString *deviceToken;
 
-+ (NSString*) Name;
++ (NSString *)Name;
 
-+ (NSString*) payloadWithDeviceToken:(NSString*)deviceToken tags:(NSSet*)tags;
++ (NSString *)payloadWithDeviceToken:(NSString *)deviceToken tags:(NSSet *)tags;
 
 @end
-
-
-

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBRegistration.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBRegistration.m
@@ -7,28 +7,29 @@
 
 @implementation SBRegistration
 
-NSString* const nativeRegistrationName = @"$Default";
+NSString *const nativeRegistrationName = @"$Default";
 
-NSString* const nativeRegistrationFormat = @"<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"text/xml\"><AppleRegistrationDescription xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">%@<DeviceToken>%@</DeviceToken></AppleRegistrationDescription></content></entry>";
+NSString *const nativeRegistrationFormat = @"<entry xmlns=\"http://www.w3.org/2005/Atom\"><content "
+                                           @"type=\"text/xml\"><AppleRegistrationDescription "
+                                           @"xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                                           @"xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/"
+                                           @"connect\">%@<DeviceToken>%@</DeviceToken></"
+                                           @"AppleRegistrationDescription></content></entry>";
 
 @synthesize ETag, expiresAt, tags, deviceToken, registrationId;
 
-+ (NSString*) Name
-{
-    return nativeRegistrationName;
++ (NSString *)Name {
+  return nativeRegistrationName;
 }
 
-+ (NSString*) payloadWithDeviceToken:(NSString*)deviceToken tags:(NSSet*)tags
-{
-    NSString* tagNode = @"";
-    NSString* tagString = [SBNotificationHubHelper convertTagSetToString:tags];
-    if( [tagString length]>0)
-    {
-        tagNode = [NSString stringWithFormat:@"<Tags>%@</Tags>", tagString];
-    }
-    
-    return [NSString stringWithFormat:nativeRegistrationFormat, tagNode, deviceToken];
++ (NSString *)payloadWithDeviceToken:(NSString *)deviceToken tags:(NSSet *)tags {
+  NSString *tagNode = @"";
+  NSString *tagString = [SBNotificationHubHelper convertTagSetToString:tags];
+  if ([tagString length] > 0) {
+    tagNode = [NSString stringWithFormat:@"<Tags>%@</Tags>", tagString];
+  }
+
+  return [NSString stringWithFormat:nativeRegistrationFormat, tagNode, deviceToken];
 }
 
 @end
-

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBTemplateRegistration.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBTemplateRegistration.h
@@ -2,15 +2,20 @@
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //----------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
 #import "SBRegistration.h"
+#import <Foundation/Foundation.h>
 
 @interface SBTemplateRegistration : SBRegistration
 
-@property (copy, nonatomic) NSString* bodyTemplate;
-@property (copy, nonatomic) NSString* expiry;
-@property (copy, nonatomic) NSString* templateName;
+@property(copy, nonatomic) NSString *bodyTemplate;
+@property(copy, nonatomic) NSString *expiry;
+@property(copy, nonatomic) NSString *templateName;
 
-+ (NSString*) payloadWithDeviceToken:(NSString*)deviceToken bodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate priorityTemplate:(NSString*)priorityTemplate tags:(NSSet*)tags templateName:(NSString *)templateName;
++ (NSString *)payloadWithDeviceToken:(NSString *)deviceToken
+                        bodyTemplate:(NSString *)bodyTemplate
+                      expiryTemplate:(NSString *)expiryTemplate
+                    priorityTemplate:(NSString *)priorityTemplate
+                                tags:(NSSet *)tags
+                        templateName:(NSString *)templateName;
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/SBTemplateRegistration.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/SBTemplateRegistration.m
@@ -7,32 +7,40 @@
 
 @implementation SBTemplateRegistration
 
-NSString* const templateRegistrationFormat = @"<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"text/xml\"><AppleTemplateRegistrationDescription xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">%@<DeviceToken>%@</DeviceToken><BodyTemplate><![CDATA[%@]]></BodyTemplate>%@%@<TemplateName>%@</TemplateName></AppleTemplateRegistrationDescription></content></entry>";
+NSString *const templateRegistrationFormat = @"<entry xmlns=\"http://www.w3.org/2005/Atom\"><content "
+                                             @"type=\"text/xml\"><AppleTemplateRegistrationDescription "
+                                             @"xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                                             @"xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/"
+                                             @"connect\">%@<DeviceToken>%@</DeviceToken><BodyTemplate><![CDATA[%@]]></"
+                                             @"BodyTemplate>%@%@<TemplateName>%@</TemplateName></"
+                                             @"AppleTemplateRegistrationDescription></content></entry>";
 
 @synthesize bodyTemplate, expiry, templateName;
 
-+ (NSString*) payloadWithDeviceToken:(NSString*)deviceToken bodyTemplate:(NSString*)bodyTemplate expiryTemplate:(NSString*)expiryTemplate priorityTemplate:(NSString*)priorityTemplate tags:(NSSet*)tags templateName:(NSString *)templateName
-{
-    NSString* expiryFullString = @"";
-    if(expiryTemplate && [expiryTemplate length]>0)
-    {
-        expiryFullString = [NSString stringWithFormat:@"<Expiry>%@</Expiry>",expiryTemplate];
-    }
-    
-    NSString* priorityFullString = @"";
-    if(priorityTemplate && [priorityTemplate length]>0)
-    {
-        priorityFullString = [NSString stringWithFormat:@"<Priority>%@</Priority>",priorityTemplate];
-    }
-    
-    NSString* tagNode = @"";
-    NSString* tagString = [SBNotificationHubHelper convertTagSetToString:tags];
-    if( [tagString length]>0)
-    {
-        tagNode = [NSString stringWithFormat:@"<Tags>%@</Tags>", tagString];
-    }
-    
-    return [NSString stringWithFormat:templateRegistrationFormat, tagNode, deviceToken, bodyTemplate, expiryFullString, priorityFullString, templateName];
++ (NSString *)payloadWithDeviceToken:(NSString *)deviceToken
+                        bodyTemplate:(NSString *)bodyTemplate
+                      expiryTemplate:(NSString *)expiryTemplate
+                    priorityTemplate:(NSString *)priorityTemplate
+                                tags:(NSSet *)tags
+                        templateName:(NSString *)templateName {
+  NSString *expiryFullString = @"";
+  if (expiryTemplate && [expiryTemplate length] > 0) {
+    expiryFullString = [NSString stringWithFormat:@"<Expiry>%@</Expiry>", expiryTemplate];
+  }
+
+  NSString *priorityFullString = @"";
+  if (priorityTemplate && [priorityTemplate length] > 0) {
+    priorityFullString = [NSString stringWithFormat:@"<Priority>%@</Priority>", priorityTemplate];
+  }
+
+  NSString *tagNode = @"";
+  NSString *tagString = [SBNotificationHubHelper convertTagSetToString:tags];
+  if ([tagString length] > 0) {
+    tagNode = [NSString stringWithFormat:@"<Tags>%@</Tags>", tagString];
+  }
+
+  return [NSString
+      stringWithFormat:templateRegistrationFormat, tagNode, deviceToken, bodyTemplate, expiryFullString, priorityFullString, templateName];
 }
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/WindowsAzureMessaging.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/WindowsAzureMessaging.h
@@ -3,12 +3,12 @@
 //----------------------------------------------------------------
 
 // Legacy API
-#import "SBNotificationHub.h"
 #import "SBConnectionString.h"
+#import "SBNotificationHub.h"
 
 // New API
-#import "MSNotificationHub.h"
 #import "MSInstallation.h"
 #import "MSInstallationTemplate.h"
-#import "MSNotificationHubMessage.h"
+#import "MSNotificationHub.h"
 #import "MSNotificationHubDelegate.h"
+#import "MSNotificationHubMessage.h"


### PR DESCRIPTION
Going forward, we will be using Clang Formatting which for now is just running the following:

```bash
clang-format -i -style=file *.h *.m
```

This will be automatically hooked into our pre-commit to ensure that we have properly formatted files