### PR TITLE
Refine Installation Templates

### DIFF
--- a/src/AzureNotificationHubs-iOS.podspec
+++ b/src/AzureNotificationHubs-iOS.podspec
@@ -1,9 +1,12 @@
 Pod::Spec.new do |s|
   s.name                = "AzureNotificationHubs-iOS"
-  s.version             = "3.0.0-preview1"
+  s.version             = "NEW_VERSION_NUMBER"
+  s.platform            = :ios, "9.0"
   s.source              = { :http => "https://github.com/Azure/azure-notificationhubs-ios/releases/download/#{s.version}/WindowsAzureMessaging.framework.zip" }
+  s.frameworks          = "Foundation", "SystemConfiguration"
+  s.ios.frameworks      = "UIKit"
+  s.ios.weak_frameworks = "UserNotifications"  
   s.vendored_frameworks = "WindowsAzureMessaging.framework"
-  s.platform            = :ios, "8.0"
   s.author              = { "Microsoft" => "http://microsoft.com" }
   s.documentation_url   = "https://docs.microsoft.com/en-us/azure/notification-hubs/"
   s.homepage            = "http://azure.microsoft.com/en-us/services/notification-hubs/"
@@ -12,5 +15,183 @@ Pod::Spec.new do |s|
   s.description         = <<-DESC
 Azure Notification Hubs provide an easy-to-use, multiplatform, scaled-out push infrastructure that enables you to send mobile push notifications from any backend (in the cloud or on-premises) to any mobile platform.
 DESC
-  s.license             = { :type => "Apache 2.0", :file => "License" }
+  s.license             = { :type => "Apache 2.0", :text => <<-LICENSE
+  Apache License
+  Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+LICENSE
+                          }
 end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
@@ -1059,7 +1059,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/WindowsAzureMessagingTests/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1068,6 +1068,7 @@
 				MARKETING_VERSION = 3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.WindowsAzureMessaging;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1122,7 +1123,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/WindowsAzureMessagingTests/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1347,6 +1348,8 @@
 				DSTROOT = /tmp/WindowsAzureMessaging.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1361,6 +1364,7 @@
 				DSTROOT = /tmp/WindowsAzureMessaging.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				OTHER_CFLAGS = "-fembed-bitcode";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		1406DA6824654C8300F47E96 /* MSInstallationTemplateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1406DA6724654C8300F47E96 /* MSInstallationTemplateTests.m */; };
+		1406DA6824654C8300F47E96 /* MSNotificationHubTemplatesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1406DA6724654C8300F47E96 /* MSNotificationHubTemplatesTests.m */; };
 		14A17DEB24628CDB00255FF2 /* MSDebounceInstallationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 14A17DE924628CDA00255FF2 /* MSDebounceInstallationManager.h */; };
 		14A17DEC24628CDB00255FF2 /* MSDebounceInstallationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 14A17DE924628CDA00255FF2 /* MSDebounceInstallationManager.h */; };
 		14A17DED24628CDB00255FF2 /* MSDebounceInstallationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14A17DEA24628CDB00255FF2 /* MSDebounceInstallationManager.m */; };
@@ -36,6 +36,12 @@
 		4C2C05D7246C694F00877B9E /* MSInstallationManagerPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2C05D6246C694F00877B9E /* MSInstallationManagerPrivate.h */; };
 		4C2C05D8246C694F00877B9E /* MSInstallationManagerPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2C05D6246C694F00877B9E /* MSInstallationManagerPrivate.h */; };
 		4C7B719E2469E13100BF416F /* MSInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8546FC244F8F49005F6B49 /* MSInstallation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4C7BF48E2474764400B8DF8A /* MSTagHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C7BF48D2474764400B8DF8A /* MSTagHelper.h */; };
+		4C7BF48F2474764400B8DF8A /* MSTagHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C7BF48D2474764400B8DF8A /* MSTagHelper.h */; };
+		4C7BF4982474779900B8DF8A /* MSTagHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7BF4972474779900B8DF8A /* MSTagHelper.m */; };
+		4C7BF4992474779900B8DF8A /* MSTagHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7BF4972474779900B8DF8A /* MSTagHelper.m */; };
+		4C7BF49B24747F6C00B8DF8A /* MSInstallationTemplateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7BF49A24747F6C00B8DF8A /* MSInstallationTemplateTests.m */; };
+		4C7BF49D247481BF00B8DF8A /* MSNotificationHubTagsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7BF49C247481BF00B8DF8A /* MSNotificationHubTagsTests.m */; };
 		4C8546ED244F5D48005F6B49 /* WindowsAzureMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C8546EC244F5D48005F6B49 /* WindowsAzureMessagingTests.m */; };
 		4C854706244FD64C005F6B49 /* MSNotificationHub.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C854705244FD64C005F6B49 /* MSNotificationHub.m */; };
 		4C854707244FD64C005F6B49 /* MSNotificationHub.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C854705244FD64C005F6B49 /* MSNotificationHub.m */; };
@@ -244,7 +250,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1406DA6724654C8300F47E96 /* MSInstallationTemplateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSInstallationTemplateTests.m; sourceTree = "<group>"; };
+		1406DA6724654C8300F47E96 /* MSNotificationHubTemplatesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSNotificationHubTemplatesTests.m; sourceTree = "<group>"; };
 		14A17DE924628CDA00255FF2 /* MSDebounceInstallationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSDebounceInstallationManager.h; sourceTree = "<group>"; };
 		14A17DEA24628CDB00255FF2 /* MSDebounceInstallationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSDebounceInstallationManager.m; sourceTree = "<group>"; };
 		14BFB06A246E8E0400059DD2 /* MSInstallationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSInstallationTests.m; sourceTree = "<group>"; };
@@ -252,6 +258,10 @@
 		2A45D3B3246CCB8F004581C4 /* MSNotificationHubMessageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSNotificationHubMessageTests.m; sourceTree = "<group>"; };
 		35B4DBCB22268CB900EAC781 /* WindowsAzureMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WindowsAzureMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C2C05D6246C694F00877B9E /* MSInstallationManagerPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSInstallationManagerPrivate.h; sourceTree = "<group>"; };
+		4C7BF48D2474764400B8DF8A /* MSTagHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSTagHelper.h; sourceTree = "<group>"; };
+		4C7BF4972474779900B8DF8A /* MSTagHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSTagHelper.m; sourceTree = "<group>"; };
+		4C7BF49A24747F6C00B8DF8A /* MSInstallationTemplateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSInstallationTemplateTests.m; sourceTree = "<group>"; };
+		4C7BF49C247481BF00B8DF8A /* MSNotificationHubTagsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSNotificationHubTagsTests.m; sourceTree = "<group>"; };
 		4C8546EA244F5D48005F6B49 /* WindowsAzureMessagingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WindowsAzureMessagingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C8546EC244F5D48005F6B49 /* WindowsAzureMessagingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WindowsAzureMessagingTests.m; sourceTree = "<group>"; };
 		4C8546EE244F5D48005F6B49 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -375,6 +385,7 @@
 			children = (
 				14BFB06A246E8E0400059DD2 /* MSInstallationTests.m */,
 				2A45D3B3246CCB8F004581C4 /* MSNotificationHubMessageTests.m */,
+				4C7BF49A24747F6C00B8DF8A /* MSInstallationTemplateTests.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -392,7 +403,8 @@
 				B3D2856024570EE300C78CC8 /* MSHttpUtilTests.m */,
 				64F993E8245C7FB60086ABF8 /* MSInstallationManagerTests.m */,
 				4C8546EE244F5D48005F6B49 /* Info.plist */,
-				1406DA6724654C8300F47E96 /* MSInstallationTemplateTests.m */,
+				1406DA6724654C8300F47E96 /* MSNotificationHubTemplatesTests.m */,
+				4C7BF49C247481BF00B8DF8A /* MSNotificationHubTagsTests.m */,
 			);
 			path = WindowsAzureMessagingTests;
 			sourceTree = "<group>";
@@ -406,6 +418,8 @@
 				6489DDFB24586C210021CF36 /* MSNotificationHubMessage.m */,
 				CE98706924644F9900A71FA3 /* MSInstallationTemplate.m */,
 				14E28A1F246A863D00B976C4 /* MSInstallationTemplate.h */,
+				4C7BF48D2474764400B8DF8A /* MSTagHelper.h */,
+				4C7BF4972474779900B8DF8A /* MSTagHelper.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -657,6 +671,7 @@
 				B3D2855D2456F1F200C78CC8 /* MSHttpClientDelegate.h in Headers */,
 				B3D285542456F09900C78CC8 /* MS_Reachability.h in Headers */,
 				B34BA7A42458A11F002457DC /* SBRegistration.h in Headers */,
+				4C7BF48F2474764400B8DF8A /* MSTagHelper.h in Headers */,
 				14E28A21246A863D00B976C4 /* MSInstallationTemplate.h in Headers */,
 				B3D285362456E97F00C78CC8 /* MSHttpCall.h in Headers */,
 				B3D285322456E97F00C78CC8 /* MSHttpUtil.h in Headers */,
@@ -697,6 +712,7 @@
 				4C7B719E2469E13100BF416F /* MSInstallation.h in Headers */,
 				848CB70A16FBE52D00183E8D /* SBTemplateRegistration.h in Headers */,
 				B3D285352456E97F00C78CC8 /* MSHttpCall.h in Headers */,
+				4C7BF48E2474764400B8DF8A /* MSTagHelper.h in Headers */,
 				A358373F16AA3B140041E372 /* SBRegistrationParser.h in Headers */,
 				B3D285412456ED2200C78CC8 /* MSNotificationHubErrors.h in Headers */,
 				B3D285562456F0D400C78CC8 /* MSDispatcherUtil.h in Headers */,
@@ -928,6 +944,7 @@
 				B3D2855A2456F0E700C78CC8 /* MSDispatcherUtil.m in Sources */,
 				B34BA79224589FDD002457DC /* SBNotificationHub.m in Sources */,
 				B34BA7A32458A11D002457DC /* SBRegistration.m in Sources */,
+				4C7BF4992474779900B8DF8A /* MSTagHelper.m in Sources */,
 				B34BA7962458A00A002457DC /* SBRegistrationParser.m in Sources */,
 				B34BA79C2458A0FB002457DC /* SBTokenProvider.m in Sources */,
 				B3D285342456E97F00C78CC8 /* MSHttpUtil.m in Sources */,
@@ -948,10 +965,12 @@
 			files = (
 				64F993E5245C5D9A0086ABF8 /* MSTokenProviderTests.m in Sources */,
 				14BFB072246E8E0400059DD2 /* MSInstallationTests.m in Sources */,
-				1406DA6824654C8300F47E96 /* MSInstallationTemplateTests.m in Sources */,
+				1406DA6824654C8300F47E96 /* MSNotificationHubTemplatesTests.m in Sources */,
 				B300E34F2458628C008A32DA /* HTTPStubsResponse+JSON.m in Sources */,
+				4C7BF49B24747F6C00B8DF8A /* MSInstallationTemplateTests.m in Sources */,
 				2A45D3B4246CCB8F004581C4 /* MSNotificationHubMessageTests.m in Sources */,
 				B3D2856224570EE400C78CC8 /* MSHttpClientTests.m in Sources */,
+				4C7BF49D247481BF00B8DF8A /* MSNotificationHubTagsTests.m in Sources */,
 				B3D2856424570EE400C78CC8 /* MSHttpUtilTests.m in Sources */,
 				4C8546ED244F5D48005F6B49 /* WindowsAzureMessagingTests.m in Sources */,
 				B300E3532458628C008A32DA /* HTTPStubs+NSURLSessionConfiguration.m in Sources */,
@@ -985,6 +1004,7 @@
 				A358374916AA3B250041E372 /* SBRegistration.m in Sources */,
 				14A17DED24628CDB00255FF2 /* MSDebounceInstallationManager.m in Sources */,
 				A358374616AA3B210041E372 /* SBConnectionString.m in Sources */,
+				4C7BF4982474779900B8DF8A /* MSTagHelper.m in Sources */,
 				CEA47C3B24598D2D007B17B3 /* MSInstallationManager.m in Sources */,
 				64F993E1245C49DE0086ABF8 /* MSInstallation.m in Sources */,
 				CE98A7852453306300DA1AE8 /* MSLocalStorage.m in Sources */,

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.m
@@ -317,7 +317,6 @@ static dispatch_once_t onceToken;
 }
 
 - (MSInstallationTemplate *)getTemplate:(NSString *)key {
-    MSInstallation *i = [self getInstallation];
     return [[self getInstallation] getTemplate:key];
 }
 

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallation.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallation.h
@@ -9,8 +9,8 @@
 @interface MSInstallation : NSObject <NSCoding>
 
 @property(nonatomic, copy) NSString *installationID, *pushChannel;
-@property(nonatomic, copy) NSDictionary<NSString *, MSInstallationTemplate *> *templates;
-@property(nonatomic, copy) NSSet<NSString *> *tags;
+@property(nonatomic, readonly, copy) NSDictionary<NSString *, MSInstallationTemplate *> *templates;
+@property(nonatomic, readonly, copy) NSSet<NSString *> *tags;
 
 - (instancetype)initWithDeviceToken:(NSString *)deviceToken;
 
@@ -19,7 +19,9 @@
 
 - (NSData *)toJsonData;
 
+- (BOOL)addTag:(NSString *)tag;
 - (BOOL)addTags:(NSArray<NSString *> *)tags;
+- (BOOL)removeTag:(NSString *)tag;
 - (BOOL)removeTags:(NSArray<NSString *> *)tags;
 - (NSArray<NSString *> *)getTags;
 - (void)clearTags;
@@ -27,7 +29,5 @@
 - (BOOL)addTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key;
 - (BOOL)removeTemplate:(NSString *)key;
 - (MSInstallationTemplate *)getTemplate:(NSString *)key;
-
-- (NSDictionary *)toDictionary;
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallation.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallation.m
@@ -4,6 +4,14 @@
 
 #import "MSInstallation.h"
 #import "MSInstallationTemplate.h"
+#import "MSTagHelper.h"
+
+@interface MSInstallation ()
+
+@property(nonatomic, copy) NSDictionary<NSString *, MSInstallationTemplate *> *templates;
+@property(nonatomic, copy) NSSet<NSString *> *tags;
+
+@end
 
 @implementation MSInstallation
 
@@ -81,11 +89,15 @@
     return [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingPrettyPrinted error:nil];
 }
 
+- (BOOL)addTag:(NSString *)tag {
+    return [self addTags:[NSArray arrayWithObject:tag]];
+}
+
 - (BOOL)addTags:(NSArray<NSString *> *)tags {
     NSMutableSet *tmpTags = [NSMutableSet setWithSet:self.tags];
 
     for (NSString *tag in tags) {
-        if ([MSInstallation isValidTag:tag]) {
+        if (isValidTag(tag)) {
             [tmpTags addObject:tag];
         } else {
             NSLog(@"Invalid tag: %@", tag);
@@ -99,6 +111,10 @@
 
 - (NSArray<NSString *> *)getTags {
     return [[self.tags copy] allObjects];
+}
+
+- (BOOL)removeTag:(NSString *)tag {
+    return [self removeTags:[NSArray arrayWithObject:tag]];
 }
 
 - (BOOL)removeTags:(NSArray<NSString *> *)tags {
@@ -161,15 +177,6 @@
     }
 
     return [self isEqualToMSInstallation:(MSInstallation *)object];
-}
-
-+ (BOOL)isValidTag:(NSString *)tag {
-    NSString *tagPattern = @"^[a-zA-Z0-9_@#\\.:\\-]{1,120}$";
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:tagPattern
-                                                                           options:NSRegularExpressionCaseInsensitive
-                                                                             error:nil];
-
-    return [regex numberOfMatchesInString:tag options:0 range:NSMakeRange(0, tag.length)] > 0;
 }
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallationTemplate.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallationTemplate.h
@@ -7,12 +7,22 @@
 @interface MSInstallationTemplate : NSObject
 
 @property(nonatomic, copy) NSString *body;
-@property(nonatomic, copy) NSSet<NSString *> *tags;
-@property(nonatomic, copy) NSDictionary<NSString *, NSString *> *headers;
+@property(nonatomic, copy, readonly) NSSet<NSString *> *tags;
+@property(nonatomic, copy, readonly) NSDictionary<NSString *, NSString *> *headers;
 
-- (void)addTag:(NSString *)tags;
+- (BOOL)addTag:(NSString *)tag;
+- (BOOL)addTags:(NSArray<NSString *> *)tagsToAdd;
+- (BOOL)removeTag:(NSString *)tag;
+- (BOOL)removeTags:(NSArray<NSString *> *)tagsToRemove;
+- (void)clearTags;
+
+// Headers
 - (void)setHeader:(NSString *)value forKey:(NSString *)key;
+- (void)removeHeader:(NSString *)key;
+- (NSString *)getHeader:(NSString *)key;
+- (NSDictionary<NSString *, NSString *> *)getHeaders;
 
+// Serialize
 - (NSDictionary *)toDictionary;
 
 @end

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallationTemplate.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSInstallationTemplate.m
@@ -3,6 +3,14 @@
 //----------------------------------------------------------------
 
 #import "MSInstallationTemplate.h"
+#import "MSTagHelper.h"
+
+@interface MSInstallationTemplate ()
+
+@property(nonatomic, copy) NSSet<NSString *> *tags;
+@property(nonatomic, copy) NSDictionary<NSString *, NSString *> *headers;
+
+@end
 
 @implementation MSInstallationTemplate
 
@@ -18,11 +26,60 @@
     return self;
 }
 
-- (void)addTag:(NSString *)tag {
-    NSMutableSet *tmpTags = [NSMutableSet setWithSet:tags];
-    [tmpTags addObject:tag];
-    tags = [tmpTags copy];
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    if (self = [super init]) {
+        body = [coder decodeObjectForKey:@"body"] ?: @"";
+        tags = [coder decodeObjectForKey:@"tags"];
+        headers = [coder decodeObjectForKey:@"headers"];
+    }
+
+    return self;
 }
+
+#pragma mark Tags
+
+- (BOOL)addTag:(NSString *)tag {
+    return [self addTags:[NSArray arrayWithObject:tag]];
+}
+
+- (BOOL)addTags:(NSArray<NSString *> *)tagsToAdd {
+    NSMutableSet *tmpTags = [NSMutableSet setWithSet:self.tags];
+
+    for (NSString *tag in tagsToAdd) {
+        if (isValidTag(tag)) {
+            [tmpTags addObject:tag];
+        } else {
+            NSLog(@"Invalid tag: %@", tag);
+            return NO;
+        }
+    }
+
+    self.tags = [tmpTags copy];
+    return YES;
+}
+
+- (NSArray<NSString *> *)getTags {
+    return [[self.tags copy] allObjects];
+}
+
+- (BOOL)removeTag:(NSString *)tag {
+    return [self removeTags:[NSArray arrayWithObject:tag]];
+}
+
+- (BOOL)removeTags:(NSArray<NSString *> *)tagsToRemove {
+    NSMutableSet *tmpTags = [NSMutableSet setWithSet:self.tags];
+
+    [tmpTags minusSet:[NSSet setWithArray:tagsToRemove]];
+
+    self.tags = [tmpTags copy];
+    return YES;
+}
+
+- (void)clearTags {
+    self.tags = [NSSet new];
+}
+
+#pragma mark Headers
 
 - (void)setHeader:(NSString *)value forKey:(NSString *)key {
     NSMutableDictionary *tmpHeaders = [NSMutableDictionary dictionaryWithDictionary:headers];
@@ -30,14 +87,24 @@
     headers = [tmpHeaders copy];
 }
 
-- (NSUInteger)hash {
-    return [self.body hash] ^ [self.headers hash] ^ [self.tags hash];
+- (void)removeHeader:(NSString *)key {
+       NSMutableDictionary *tmpHeaders = [NSMutableDictionary dictionaryWithDictionary:headers];
+    [tmpHeaders removeObjectForKey:key];
+    headers = [tmpHeaders copy];
 }
 
-- (void)encodeWithCoder:(nonnull NSCoder *)coder {
-    [coder encodeObject:body forKey:@"body"];
-    [coder encodeObject:tags forKey:@"tags"];
-    [coder encodeObject:headers forKey:@"headers"];
+- (NSString *)getHeader:(NSString *)key {
+    return [headers objectForKey:key];
+}
+
+- (NSDictionary<NSString *, NSString *> *)getHeaders {
+    return [headers copy];
+}
+
+#pragma mark Equality
+
+- (NSUInteger)hash {
+    return [self.body hash] ^ [self.headers hash] ^ [self.tags hash];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -56,14 +123,10 @@
     return [body isEqualToString:template.body] && [tags isEqualToSet:template.tags] && [headers isEqualToDictionary:template.headers];
 }
 
-- (instancetype)initWithCoder:(NSCoder *)coder {
-    if (self = [super init]) {
-        body = [coder decodeObjectForKey:@"body"] ?: @"";
-        tags = [coder decodeObjectForKey:@"tags"];
-        headers = [coder decodeObjectForKey:@"headers"];
-    }
-
-    return self;
+- (void)encodeWithCoder:(nonnull NSCoder *)coder {
+    [coder encodeObject:body forKey:@"body"];
+    [coder encodeObject:tags forKey:@"tags"];
+    [coder encodeObject:headers forKey:@"headers"];
 }
 
 - (NSDictionary *)toDictionary {

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSTagHelper.h
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSTagHelper.h
@@ -1,0 +1,7 @@
+//----------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//----------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+BOOL isValidTag(NSString *tag);

--- a/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSTagHelper.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessaging/Models/MSTagHelper.m
@@ -1,0 +1,15 @@
+//----------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//----------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSTagHelper.h"
+
+BOOL isValidTag(NSString *tag) {
+    NSString *tagPattern = @"^[a-zA-Z0-9_@#\\.:\\-]{1,120}$";
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:tagPattern
+                                                                           options:NSRegularExpressionCaseInsensitive
+                                                                             error:nil];
+
+    return [regex numberOfMatchesInString:tag options:0 range:NSMakeRange(0, tag.length)] > 0;
+}

--- a/src/WindowsAzureMessaging/WindowsAzureMessagingTests/MSNotificationHubTagsTests.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessagingTests/MSNotificationHubTagsTests.m
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import "MSInstallationManager.h"
+#import "MSLocalStorage.h"
+#import "MSTestFrameworks.h"
+#import "WindowsAzureMessaging.h"
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+
+@interface MSNotificationHubTagsTests : XCTestCase
+
+@end
+
+@implementation MSNotificationHubTagsTests
+
+static NSString *connectionString = @"Endpoint=sb://test-namespace.servicebus.windows.net/"
+                                    @";SharedAccessKeyName=DefaultListenSharedAccessSignature;SharedAccessKey=HqKHjkhjg674hjGHdskJ795GJFJ=";
+static NSString *hubName = @"nubName";
+
+- (void)setUp {
+    [super setUp];
+
+    id notificationCenterMock = OCMClassMock([UNUserNotificationCenter class]);
+    OCMStub(ClassMethod([notificationCenterMock currentNotificationCenter])).andReturn(nil);
+
+    [MSNotificationHub initWithConnectionString:connectionString hubName:hubName];
+}
+
+- (void)testAddTag {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [MSLocalStorage upsertInstallation:installation];
+
+    // Then
+    XCTAssertTrue([MSNotificationHub addTag:@"tag1"]);
+    MSInstallation *installationWithTag = [MSLocalStorage loadInstallation];
+    XCTAssertTrue([installationWithTag.tags count] == 1, @"Installation tags count actually is %lul", [installationWithTag.tags count]);
+    XCTAssertTrue([installationWithTag.tags containsObject:@"tag1"]);
+}
+
+- (void)testAddTagFailsIfTagDoesNotMatchPattern {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [MSLocalStorage upsertInstallation:installation];
+
+    // Then
+    XCTAssertFalse([MSNotificationHub addTag:@"tag 1"]);
+    MSInstallation *installationWithTag = [MSLocalStorage loadInstallation];
+    XCTAssertFalse([installationWithTag.tags containsObject:@"tag 1"]);
+}
+
+- (void)testAddTagFailsIfTagAlreadyExist {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [installation addTags:@[ @"tag1", @"tag2" ]];
+    [MSLocalStorage upsertInstallation:installation];
+
+    // Then
+    XCTAssertTrue([MSNotificationHub addTag:@"tag1"]);
+    MSInstallation *installationWithTag = [MSLocalStorage loadInstallation];
+    XCTAssertTrue([installationWithTag.tags count] == 2, @"Installation tags count actually is %lul", [installationWithTag.tags count]);
+}
+
+- (void)testAddTags {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [MSLocalStorage upsertInstallation:installation];
+    NSArray<NSString *> *tags = @[ @"tag1", @"tag2" ];
+
+    // Then
+    XCTAssertTrue([MSNotificationHub addTags:tags]);
+    MSInstallation *installationWithTag = [MSLocalStorage loadInstallation];
+    XCTAssertTrue([installationWithTag.tags count] == 2, @"Installation tags count actually is %lul", [installationWithTag.tags count]);
+    XCTAssertTrue([installationWithTag.tags containsObject:@"tag1"]);
+    XCTAssertTrue([installationWithTag.tags containsObject:@"tag2"]);
+}
+
+- (void)testRemoveTags {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [installation addTags:@[ @"tag1", @"tag2", @"tag3" ]];
+    [MSLocalStorage upsertInstallation:installation];
+    NSArray<NSString *> *tags = @[ @"tag1", @"tag2" ];
+
+    // Then
+    XCTAssertTrue([MSNotificationHub removeTags:tags]);
+    MSInstallation *installationWithTag = [MSLocalStorage loadInstallation];
+    XCTAssertTrue([installationWithTag.tags count] == 1, @"Installation tags count actually is %lul", [installationWithTag.tags count]);
+    XCTAssertTrue([installationWithTag.tags containsObject:@"tag3"]);
+}
+
+- (void)testRemoveTagsFailsIfInstallationDoesNotHaveTags {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [MSLocalStorage upsertInstallation:installation];
+    NSArray<NSString *> *tags = @[ @"tag1", @"tag2" ];
+
+    // Then
+    XCTAssertFalse([MSNotificationHub removeTags:tags]);
+}
+
+- (void)testClearTags {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [installation addTags:@[ @"tag1", @"tag2", @"tag3" ]];
+    [MSLocalStorage upsertInstallation:installation];
+
+    // Then
+    XCTAssertNoThrow([MSNotificationHub clearTags]);
+    MSInstallation *installationWithTag = [MSLocalStorage loadInstallation];
+    XCTAssertTrue([installationWithTag.tags count] == 0, @"Installation tags count actually is %lul", [installationWithTag.tags count]);
+}
+
+- (void)testGetTags {
+    // If
+    MSInstallation *installation = [MSInstallation new];
+    [installation addTags:@[ @"tag1", @"tag2", @"tag3" ]];
+    [MSLocalStorage upsertInstallation:installation];
+
+    // When
+    NSArray<NSString *> *tags = [MSNotificationHub getTags];
+
+    // Then
+    XCTAssertNotNil(tags);
+    XCTAssertTrue([tags count] == 3, @"Installation tags count actually is %lul", [tags count]);
+}
+
+@end

--- a/src/WindowsAzureMessaging/WindowsAzureMessagingTests/MSNotificationHubTemplatesTests.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessagingTests/MSNotificationHubTemplatesTests.m
@@ -1,5 +1,5 @@
-//  MSInstallationTemplateTests.m
-//  WindowsAzureMessagingTests
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 #import "MSInstallationManager.h"
 #import "MSInstallationTemplate.h"
@@ -9,11 +9,11 @@
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>
 
-@interface MSInstallationTemplateTests : XCTestCase
+@interface MSNotificationHubTemplateTests : XCTestCase
 @property MSInstallationTemplate *template;
 @end
 
-@implementation MSInstallationTemplateTests
+@implementation MSNotificationHubTemplateTests
 
 static NSString *connectionString = @"Endpoint=sb://test-namespace.servicebus.windows.net/"
                                     @";SharedAccessKeyName=DefaultListenSharedAccessSignature;SharedAccessKey=HqKHjkhjg674hjGHdskJ795GJFJ=";

--- a/src/WindowsAzureMessaging/WindowsAzureMessagingTests/Models/MSInstallationTemplateTests.m
+++ b/src/WindowsAzureMessaging/WindowsAzureMessagingTests/Models/MSInstallationTemplateTests.m
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import <Foundation/Foundation.h>
+#import "MSTestFrameworks.h"
+#import "WindowsAzureMessaging.h"
+
+@interface MSInstallationTemplateTests : XCTestCase
+
+@end
+
+@implementation MSInstallationTemplateTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)testAddTag {
+    // Arrange
+    MSInstallationTemplate *template = [MSInstallationTemplate new];
+    
+    // Act
+    XCTAssertTrue([template addTag:@"tag1"]);
+    
+    // Assert
+    XCTAssertEqual(1, [[template tags] count]);
+}
+
+- (void)testAddTagDuplicateDoesNotAdd {
+    MSInstallationTemplate *template = [MSInstallationTemplate new];
+    
+    // Act
+    XCTAssertTrue([template addTag:@"tag1"]);
+    
+    // Assert
+    XCTAssertTrue([template addTag:@"tag1"]);
+    XCTAssertEqual(1, [[template tags] count]);
+}
+
+- (void)testAddTagInvalidReturnsFalse {
+    // Arrange
+    MSInstallationTemplate *template = [MSInstallationTemplate new];
+    NSString *tag = @"tag 1";
+    
+    // Act/Assert
+    XCTAssertFalse([template addTag:tag]);
+}
+
+- (void)testAddTags {
+    // Arrange
+    MSInstallationTemplate *template = [MSInstallationTemplate new];
+    NSArray *tags = @[ @"tag1", @"tag2", @"tag3" ];
+    
+    // Act
+    XCTAssertTrue([template addTags:tags]);
+                   
+    // Assert
+    XCTAssertEqual(3, [[template tags] count]);
+}
+
+@end

--- a/src/lintPod.command
+++ b/src/lintPod.command
@@ -1,12 +1,10 @@
 # Run lint to validate podspec
-resp="$(pod spec lint ./AzureNotificationHubs-iOS.podspec)"
-echo $resp
+pod spec lint ./AzureNotificationHubs-iOS.podspec --verbose
+retval=$?
 
-# Check error from the response
-error="$(echo $resp | grep -i 'error\|fatal|The spec did not pass validation')"
-if [ "$error" ]; then
-    echo "Cannot publish to CocoaPods due to spec validation failure"
+if [ $retval -eq 0 ]; then
+    echo $'\360\237\215\272 Podspec validated successfully'
+else
+    echo -e '\xf0\x9f\x91\xbf Cannot publish to CocoaPods due to spec validation failure'
     exit 1
 fi
-
-echo "Podspec validated successfully"

--- a/src/publishPod.command
+++ b/src/publishPod.command
@@ -1,18 +1,10 @@
 # Push podspec to CocoaPods
-resp="$(pod trunk push ./AzureNotificationHubs-iOS.podspec)"
-echo $resp
+pod trunk push ./AzureNotificationHubs-iOS.podspec
+retval=$?
 
-# Check error from the response
-error="$(echo $resp | grep -i 'error\|fatal|The spec did not pass validation')"
-if [ "$error" ]; then
-    echo "Cannot publish to CocoaPods"
+if [ $retval -eq 0 ]; then
+    echo $'\360\237\215\272 Podspec published to CocoaPods successfully"'
+else
+    echo -e '\xf0\x9f\x91\xbf Cannot publish to CocoaPods'
     exit 1
 fi
-
-successFlag="$(echo $resp | grep -i 'successfully published')"
-if [ -z "$successFlag" ]; then
-    echo "Cannot publish to CocoaPods"
-    exit 1
-fi
-
-echo "Podspec published to CocoaPods successfully"


### PR DESCRIPTION
This code refines installations and installation templates by refining the `MSInstallation` to hide the setter via an extension class.  This code also refines the `MSInstallationTemplate` to do the same for the headers and tags.  Added tests for installation templates and installations, separating out the usage of `MSNotificationHub` and `MSLocalStorage` to purely testing the `MSInstallation` and `MSInstallationTemplate` classes.