### PR TITLE
Adds tags samples for Swift and Objective-C

### DIFF
--- a/Samples/Objective-C/nhubsample-refresh/nhubsample-refresh/AppDelegate.m
+++ b/Samples/Objective-C/nhubsample-refresh/nhubsample-refresh/AppDelegate.m
@@ -23,7 +23,8 @@
     [MSNotificationHub setManagementDelegate: self];
     [MSNotificationHub setLifecycleDelegate: self];
     [MSNotificationHub startWithConnectionString:connectionString hubName:hubName];
-    [MSNotificationHub addTag:@"userAgent:com.example.nhubsample-refresh:1.0"];
+    
+    [self addTags];
     
     return YES;
 }
@@ -58,6 +59,18 @@
 
 - (void)notificationHub:(MSNotificationHub *)notificationHub didFailToSaveInstallation:(MSInstallation *)installation withError:(NSError *)error {
     NSLog(@"didFailToSaveInstallationWithError: %@", error.userInfo);
+}
+
+- (void)addTags {
+    // Get language and country code for common tag values
+    NSString *language = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
+    NSString *countryCode = [[NSLocale currentLocale] countryCode];
+    
+    // Create tags with type_value format
+    NSString *languageTag = [NSString stringWithFormat:@"language_%@", language];
+    NSString *countryCodeTag = [NSString stringWithFormat:@"country_%@", countryCode];
+    
+    [MSNotificationHub addTags:@[languageTag, countryCodeTag]];
 }
 
 #pragma mark - UISceneSession lifecycle

--- a/Samples/Swift/nhubsample-refresh/nhubsample-refresh/AppDelegate.swift
+++ b/Samples/Swift/nhubsample-refresh/nhubsample-refresh/AppDelegate.swift
@@ -24,7 +24,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSInstallationEnrichmentD
         MSNotificationHub.setManagementDelegate(self)
         MSNotificationHub.setLifecycleDelegate(self)
         MSNotificationHub.start(connectionString: connectionString!, hubName: hubName!)
-        MSNotificationHub.addTag("userAgent:com.example.nhubsample-refresh:1.0")
+        
+        addTags()
         
         return true
     }
@@ -70,7 +71,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSInstallationEnrichmentD
     }
     
     func notificationHub(_ notificationHub: MSNotificationHub!, willEnrichInstallation installation: MSInstallation!) {
-        NSLog("willEnrichInstallation");
+        NSLog("willEnrichInstallation")
     }
 
+    // Adds some basic tags such as language and country
+    func addTags() {
+        // Get language and country code for common tag values
+        let language = Bundle.main.preferredLocalizations.first!
+        let countryCode = NSLocale.current.regionCode!
+        
+        // Create tags with type_value format
+        let languageTag = "language_" + language
+        let countryCodeTag = "country_" + countryCode
+        
+        MSNotificationHub.addTags([languageTag, countryCodeTag])
+    }
+    
 }


### PR DESCRIPTION
Adds tags examples on how we want customers to use tags, using the format of `type_value`.  This adds two examples of tags, one for language and one for country code.  The language is obtained by the `NSBundle` therefore is the app language instead of the phone's preferred language.