### PR TITLE
Adding templates for issues/PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+***Exception or Stack Trace***
+Add the exception log and stack trace if available
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+***Code Snippet***
+Add the code snippet that causes the issue.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Setup (please complete the following information):**
+ - OS: [e.g. iOS]
+ - IDE : [e.g. Xcode]
+ - Version of the Library used
+
+**Additional context**
+Add any other context about the problem here.
+
+**Information Checklist**
+Kindly make sure that you have added all the following information above and checkoff the required fields otherwise we will treat the issuer as an incomplete report
+- [ ] Bug Description Added
+- [ ] Repro Steps Added
+- [ ] Setup information Added

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,8 +26,8 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Setup (please complete the following information):**
- - OS: [e.g. iOS]
- - IDE : [e.g. Xcode]
+ - OS: [e.g. iOS 13.x]
+ - IDE : [e.g. Xcode 11.x]
  - Version of the Library used
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE REQ]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Information Checklist**
+Kindly make sure that you have added all the following information above and checkoff the required fields otherwise we will treat the issuer as an incomplete report
+- [ ] Description Added
+- [ ] Expected solution specified

--- a/.github/ISSUE_TEMPLATE/question-query-template.md
+++ b/.github/ISSUE_TEMPLATE/question-query-template.md
@@ -1,0 +1,24 @@
+---
+name: Question/Query template
+about: Use this template to file a question/query for the SDK team
+title: "[QUERY]"
+labels: ''
+assignees: ''
+
+---
+
+**Query/Question**
+A clear and concise ask/query.
+
+***Why is this not a Bug or a feature Request?***
+A clear explanation of why is this not a bug or a feature request?
+
+**Setup (please complete the following information if applicable):**
+ - OS: [e.g. iOS]
+ - IDE : [e.g. Xcode]
+ - Version of the Library used
+ 
+ **Information Checklist**
+ Kindly make sure that you have added all the following information above and checkoff the required fields otherwise we will treat the issuer as an incomplete report
+- [ ] Query Added
+- [ ] Setup information Added

--- a/.github/ISSUE_TEMPLATE/question-query-template.md
+++ b/.github/ISSUE_TEMPLATE/question-query-template.md
@@ -14,8 +14,8 @@ A clear and concise ask/query.
 A clear explanation of why is this not a bug or a feature request?
 
 **Setup (please complete the following information if applicable):**
- - OS: [e.g. iOS]
- - IDE : [e.g. Xcode]
+ - OS: [e.g. iOS 13.x]
+ - IDE : [e.g. Xcode 11.x]
  - Version of the Library used
  
  **Information Checklist**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- 
+Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.
+
+We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.
+
+Thanks!
+
+The Azure Notification Hubs team -->
+
+Things to consider before you submit the PR:
+
+* [ ] Are tests passing locally?
+* [ ] Are the files formatted correctly?
+* [ ] Did you add unit tests?
+* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
+
+## Description
+
+A few sentences describing the overall goals of the pull request.
+
+## Related PRs or issues
+
+List related PRs and other issues.
+
+## Misc
+
+Add what's missing, notes on what you tested, additional thoughts or questions.


### PR DESCRIPTION
This adds templates for GitHub issues, for whether it is the following:
- Bug Report
- Feature Request
- Question

In addition, this also adds a template for Pull Requests