### PR TITLE
Adding NS_SWIFT_DISABLE_ASYNC to code

### DIFF
--- a/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
+++ b/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
@@ -390,6 +390,9 @@
 		4CA7330B24A3E984006AC99D /* MSNotificationHub.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA731FC24A1C372006AC99D /* MSNotificationHub.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CA7335024A42C64006AC99D /* MSInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA7334F24A42C64006AC99D /* MSInstallation+Private.h */; };
 		4CA7335124A42C64006AC99D /* MSInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA7334F24A42C64006AC99D /* MSInstallation+Private.h */; };
+		4CF2730026BB50FD0018E048 /* ANHAsync.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CF272FF26BB50FD0018E048 /* ANHAsync.h */; };
+		4CF2730126BB50FD0018E048 /* ANHAsync.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CF272FF26BB50FD0018E048 /* ANHAsync.h */; };
+		4CF2730226BB50FD0018E048 /* ANHAsync.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CF272FF26BB50FD0018E048 /* ANHAsync.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -735,6 +738,7 @@
 		4CA732DF24A3B38F006AC99D /* MSInstallationTemplateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSInstallationTemplateTests.m; sourceTree = "<group>"; };
 		4CA732F224A3DAC2006AC99D /* ANHApplication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ANHApplication.h; sourceTree = "<group>"; };
 		4CA7334F24A42C64006AC99D /* MSInstallation+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSInstallation+Private.h"; sourceTree = "<group>"; };
+		4CF272FF26BB50FD0018E048 /* ANHAsync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ANHAsync.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -993,6 +997,7 @@
 			children = (
 				4C10498F24ABD6B600FA339E /* DelegateForwarder */,
 				4CA732F224A3DAC2006AC99D /* ANHApplication.h */,
+				4CF272FF26BB50FD0018E048 /* ANHAsync.h */,
 				4CA731F324A1C2A2006AC99D /* MSDebounceInstallationManager.h */,
 				4CA731F624A1C2CF006AC99D /* MSDebounceInstallationManager.m */,
 				4CA731EC24A1BFE2006AC99D /* MSInstallationManager.h */,
@@ -1155,6 +1160,7 @@
 				4C3EEB3024C8AE160096C133 /* MSInstallationTemplate.h in Headers */,
 				4C3EEB4B24C8B5020096C133 /* MSNotificationHubDelegate.h in Headers */,
 				4C3EEB2924C8ADEB0096C133 /* MSTokenProvider.h in Headers */,
+				4CF2730226BB50FD0018E048 /* ANHAsync.h in Headers */,
 				4C3EEB4524C8AFF10096C133 /* SBConnectionString.h in Headers */,
 				4C3EEB3F24C8AE5A0096C133 /* MSInstallationLifecycleDelegate.h in Headers */,
 				4C3EEB3B24C8AE4A0096C133 /* ANHDispatcherUtil.h in Headers */,
@@ -1216,6 +1222,7 @@
 				4CA7319124A186A3006AC99D /* SBNotificationHub.h in Headers */,
 				4CA731FA24A1C33D006AC99D /* MSInstallationManagementDelegate.h in Headers */,
 				4CA731B624A187A6006AC99D /* SBURLConnection.h in Headers */,
+				4CF2730026BB50FD0018E048 /* ANHAsync.h in Headers */,
 				4C1049A324ABE48100FA339E /* ANHDelegateForwarder+Private.h in Headers */,
 				4CA7317C24A180C0006AC99D /* ANHHttpUtil.h in Headers */,
 				4CA731C124A18A8B006AC99D /* MSTokenProvider.h in Headers */,
@@ -1288,6 +1295,7 @@
 				4CA7318524A1820A006AC99D /* ANH_Reachability.h in Headers */,
 				4CA7315D24A17AC8006AC99D /* ANHDispatcherUtil.h in Headers */,
 				4CA731C824A1901D006AC99D /* MSLocalStorage.h in Headers */,
+				4CF2730126BB50FD0018E048 /* ANHAsync.h in Headers */,
 				4CA732BF24A2D050006AC99D /* Compatibility.h in Headers */,
 				4C3EEBA124C8BA600096C133 /* HTTPStubsMethodSwizzling.h in Headers */,
 				4CA7312324A15A25006AC99D /* WindowsAzureMessaging.h in Headers */,

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBURLConnection.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBURLConnection.m
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //----------------------------------------------------------------
 
+#import "ANHAsync.h"
 #import "SBURLConnection.h"
 #import "SBNotificationHubHelper.h"
 
@@ -16,7 +17,7 @@ static StaticHandleBlock _staticHandler;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wnullable-to-nonnull-conversion"
-- (void)sendRequest:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))completion
+- (void)sendRequest:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))completion ANH_SWIFT_DISABLE_ASYNC
 {
     if (self) {
         self->_request = request;

--- a/WindowsAzureMessaging/WindowsAzureMessaging/HttpClient/ANHHttpCall.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/HttpClient/ANHHttpCall.m
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //----------------------------------------------------------------
 
+#import "ANHAsync.h"
 #import "ANHHttpCall.h"
 
 @implementation ANHHttpCall
@@ -11,7 +12,7 @@
                     headers:(NSDictionary<NSString *, NSString *> *)headers
                        data:(NSData *)data
              retryIntervals:(NSArray *)retryIntervals
-          completionHandler:(ANHHttpRequestCompletionHandler)completionHandler {
+          completionHandler:(ANHHttpRequestCompletionHandler)completionHandler ANH_SWIFT_DISABLE_ASYNC {
     if ((self = [super init])) {
         _url = url;
         _method = method;

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Internal/ANHAsync.h
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Internal/ANHAsync.h
@@ -1,0 +1,12 @@
+//----------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//----------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+#if __has_attribute(swift_async)
+// Switch to NS_SWIFT_DISABLE_ASYNC once Xcode 13 is available
+#define ANH_SWIFT_DISABLE_ASYNC __attribute__((swift_async(none)))
+#else
+#define ANH_SWIFT_DISABLE_ASYNC
+#endif

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHNotificationHubAppDelegateForwarder.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHNotificationHubAppDelegateForwarder.m
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "ANHAsync.h"
 #import "ANHApplication.h"
 #import "ANHNotificationHubAppDelegateForwarder.h"
 #import "MSNotificationHub.h"
@@ -118,7 +119,7 @@ static ANHNotificationHubAppDelegateForwarder *sharedInstance = nil;
 
 - (void)custom_application:(UIApplication *)application
     didReceiveRemoteNotification:(NSDictionary *)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler ANH_SWIFT_DISABLE_ASYNC {
     IMP originalImp = NULL;
 
     // Forward to the original delegate.

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHUserNotificationCenterDelegateForwarder.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHUserNotificationCenterDelegateForwarder.m
@@ -4,6 +4,7 @@
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>
 
+#import "ANHAsync.h"
 #import "ANHUserNotificationCenterDelegateForwarder.h"
 #import "MSNotificationHub.h"
 
@@ -77,7 +78,7 @@ static ANHUserNotificationCenterDelegateForwarder *sharedInstance = nil;
 - (void)custom_userNotificationCenter:(UNUserNotificationCenter *)center
               willPresentNotification:(UNNotification *)notification
                 withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
-    API_AVAILABLE(ios(10.0), watchos(3.0), macos(10.14), macCatalyst(13.0)) API_UNAVAILABLE(tvos) {
+    API_AVAILABLE(ios(10.0), watchos(3.0), macos(10.14), macCatalyst(13.0)) API_UNAVAILABLE(tvos) ANH_SWIFT_DISABLE_ASYNC {
     IMP originalImp = NULL;
 
     /*
@@ -102,7 +103,7 @@ static ANHUserNotificationCenterDelegateForwarder *sharedInstance = nil;
 - (void)custom_userNotificationCenter:(UNUserNotificationCenter *)center
        didReceiveNotificationResponse:(UNNotificationResponse *)response
                 withCompletionHandler:(void (^)(void))completionHandler
-    API_AVAILABLE(ios(10.0), watchos(3.0), macos(10.14), macCatalyst(13.0))API_UNAVAILABLE(tvos) {
+    API_AVAILABLE(ios(10.0), watchos(3.0), macos(10.14), macCatalyst(13.0))API_UNAVAILABLE(tvos) ANH_SWIFT_DISABLE_ASYNC {
     IMP originalImp = NULL;
 
     /*


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This adds support for `NS_SWIFT_DISABLE_ASYNC` which passes the `-Wcompletion-handler` suppression to the Clang compiler.  This is new as of [Xcode 13 Beta](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes).  I have defined our own implementation in case it does not yet exist for Xcode 12 and previous.

## Related PRs or issues

N/A

## Misc

N/A