### PR TITLE
Fix SwiftUI Previews in Xcode 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
     products: [
         .library(
             name: "WindowsAzureMessaging",
-            type: .static,
             targets: ["WindowsAzureMessaging"]),
     ],
     dependencies: [],

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -15,7 +15,6 @@ let package = Package(
     products: [
         .library(
             name: "WindowsAzureMessaging",
-            type: .static,
             targets: ["WindowsAzureMessaging"]),
     ],
     dependencies: [],


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~~[ ] Did you add unit tests?~~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes SwiftUI Previews in Xcode 14 that failed to run when adding **Azure Notification Hubs SDK** through SPM.

## Related PRs or issues

The fix is based on this [PR](https://github.com/microsoft/appcenter-sdk-apple/pull/2433) from **Visual Studio App Center SDK**.

## Misc

This PR fixes the following issue:

An iOS project doesn't work anymore for SwiftUI Preview with Xcode 14.
The project builds and runs fine, but Preview never works. The error message is as follows:

```
HumanReadableSwiftError

SettingsError: noExecutablePath(<IDESwiftPackageStaticLibraryProductBuildable:ObjectIdentifier(0x000060001f8fee80):'WindowsAzureMessaging'>)
```

Azure Notification Hubs SDK is added thought SPM.
SwiftUI Preview with Xcode 13 works.

More information about the issue in Xcode 14 can be seen in this [Apple Developer forum thread](https://developer.apple.com/forums/thread/707569).