### PR TITLE
Fix build warning (ref #133)

### DIFF
--- a/.github/workflows/analyze-test.yml
+++ b/.github/workflows/analyze-test.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   ios-analyze-test:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
-      XC_VERSION: ${{ '12.3' }}
+      XC_VERSION: ${{ '13.4.1' }}
       XC_WORKSPACE: ${{ 'WindowsAzureMessaging.xcworkspace' }}
       XC_SCHEME: ${{ 'WindowsAzureMessaging iOS Framework' }}
     steps:
@@ -28,9 +28,9 @@ jobs:
       run: /usr/bin/xcodebuild test -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=iOS Simulator,name=iPhone 11'
 
   tvos-analyze-test:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
-      XC_VERSION: ${{ '12.3' }}
+      XC_VERSION: ${{ '13.4.1' }}
       XC_WORKSPACE: ${{ 'WindowsAzureMessaging.xcworkspace' }}
       XC_SCHEME: ${{ 'WindowsAzureMessaging tvOS Framework' }}
     steps:
@@ -48,9 +48,9 @@ jobs:
       run: /usr/bin/xcodebuild test -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=tvOS Simulator,name=Apple TV 4K'
 
   macos-analyze-test:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
-      XC_VERSION: ${{ '12.3' }}
+      XC_VERSION: ${{ '13.4.1' }}
       XC_WORKSPACE: ${{ 'WindowsAzureMessaging.xcworkspace' }}
       XC_SCHEME: ${{ 'WindowsAzureMessaging macOS Framework' }}
     steps:
@@ -68,9 +68,9 @@ jobs:
       run: /usr/bin/xcodebuild test -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=macOS'
       
   mac-catalyst-analyze-test:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
-      XC_VERSION: ${{ '12.3' }}
+      XC_VERSION: ${{ '13.4.1' }}
       XC_WORKSPACE: ${{ 'WindowsAzureMessaging.xcworkspace' }}
       XC_SCHEME: ${{ 'WindowsAzureMessaging iOS Framework' }}
     steps:

--- a/.github/workflows/analyze-test.yml
+++ b/.github/workflows/analyze-test.yml
@@ -42,10 +42,10 @@ jobs:
       run: "sudo xcode-select -switch /Applications/Xcode_$XC_VERSION.app"
 
     - name: iOS Analyze
-      run: /usr/bin/xcodebuild analyze -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=tvOS Simulator,name=Apple TV 4K'
+      run: /usr/bin/xcodebuild analyze -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=tvOS Simulator,name=Apple TV 4K (2nd generation)'
 
     - name: iOS Test
-      run: /usr/bin/xcodebuild test -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=tvOS Simulator,name=Apple TV 4K'
+      run: /usr/bin/xcodebuild test -workspace "$XC_WORKSPACE" -scheme "$XC_SCHEME" -destination 'platform=tvOS Simulator,name=Apple TV 4K (2nd generation)'
 
   macos-analyze-test:
     runs-on: macos-12

--- a/.github/workflows/framework-docs.yml
+++ b/.github/workflows/framework-docs.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   build-sdk:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
-      XC_VERSION: ${{ '12.3' }}
+      XC_VERSION: ${{ '13.4.1' }}
       XC_WORKSPACE: ${{ 'WindowsAzureMessaging.xcworkspace' }}
       XC_SCHEME: ${{ 'All Frameworks' }}
       XC_DOC_SCHEME: ${{ 'All Documentation' }}

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBTokenProvider.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBTokenProvider.m
@@ -236,7 +236,6 @@ static const int defaultTimeToExpireinMins = 20;
 }
 
 + (NSString *)ExtractToken:(NSData *)data {
-    NSString *expireInSeconds;
     NSString *token;
     NSString *rawStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     NSArray *fields = [rawStr componentsSeparatedByString:@"&"];
@@ -253,8 +252,6 @@ static const int defaultTimeToExpireinMins = 20;
         NSString *value = [SBNotificationHubHelper urlDecode:[subItems objectAtIndex:1]];
         if ([key isEqualToString:@"wrap_access_token"]) {
             token = [NSString stringWithFormat:@"WRAP access_token=\"%@\"", value];
-        } else {
-            expireInSeconds = value;
         }
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [x] Are tests passing?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests? **n/a**
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Should fix #133. There was an unused local in `+SBTokenProvider ExtractToken:`. This PR removes the local variable and fixed the build error.

I also updated the Actions workflows to use the right macOS / Xcode versions. The build image no longer has Xcode `12.3`. See the [build image docs](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode) for more information.

## Related PRs or issues

ref: #133
