### PR TITLE
Remove usage of the `template` keyword in public signatures

### DIFF
--- a/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
+++ b/WindowsAzureMessaging/WindowsAzureMessaging.xcodeproj/project.pbxproj
@@ -98,6 +98,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		2A7CB3572991F041005DB675 /* CompileObjCppTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A7CB3562991F041005DB675 /* CompileObjCppTests.mm */; };
+		2A7CB3582991F041005DB675 /* CompileObjCppTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A7CB3562991F041005DB675 /* CompileObjCppTests.mm */; };
+		2A7CB3592991F041005DB675 /* CompileObjCppTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A7CB3562991F041005DB675 /* CompileObjCppTests.mm */; };
 		4C01E9FD24BD1896003593A2 /* ANHHttpTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C01E9F824BD1896003593A2 /* ANHHttpTestUtil.m */; };
 		4C01E9FE24BD1896003593A2 /* ANHHttpTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C01E9F824BD1896003593A2 /* ANHHttpTestUtil.m */; };
 		4C01E9FF24BD1896003593A2 /* TestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C01E9FC24BD1896003593A2 /* TestHelper.m */; };
@@ -608,6 +611,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2A7CB3562991F041005DB675 /* CompileObjCppTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CompileObjCppTests.mm; sourceTree = "<group>"; };
 		4C01E9F724BD1896003593A2 /* TestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestHelper.h; sourceTree = "<group>"; };
 		4C01E9F824BD1896003593A2 /* ANHHttpTestUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ANHHttpTestUtil.m; sourceTree = "<group>"; };
 		4C01E9F924BD1896003593A2 /* MSConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSConstants.h; sourceTree = "<group>"; };
@@ -888,6 +892,7 @@
 				4CA730ED24A14FF2006AC99D /* WindowsAzureMessagingTests.m */,
 				4CA730EF24A14FF2006AC99D /* Info.plist */,
 				4CA7322124A2CCA9006AC99D /* Frameworks */,
+				2A7CB3562991F041005DB675 /* CompileObjCppTests.mm */,
 			);
 			path = WindowsAzureMessagingTests;
 			sourceTree = "<group>";
@@ -2020,6 +2025,7 @@
 				4C3EEB8924C8B9030096C133 /* ANHHttpTestUtil.m in Sources */,
 				4C3EEB8E24C8B9D10096C133 /* MSLocalStorageTests.m in Sources */,
 				4C3EEB9524C8B9F60096C133 /* HTTPStubsMethodSwizzling.m in Sources */,
+				2A7CB3592991F041005DB675 /* CompileObjCppTests.mm in Sources */,
 				4C3EEB9424C8B9F10096C133 /* HTTPStubs+NSURLSessionConfiguration.m in Sources */,
 				4C3EEB9324C8B9ED0096C133 /* HTTPStubs.m in Sources */,
 				4C3EEB8D24C8B9CE0096C133 /* MSInstallationManagerTests.m in Sources */,
@@ -2087,6 +2093,7 @@
 				4CA7329A24A2D021006AC99D /* HTTPStubsPathHelpers.m in Sources */,
 				4CA732D324A3B312006AC99D /* ANHHttpUtilTests.m in Sources */,
 				4CA732D924A3B312006AC99D /* MSLocalStorageTests.m in Sources */,
+				2A7CB3572991F041005DB675 /* CompileObjCppTests.mm in Sources */,
 				4CA732D524A3B312006AC99D /* MSInstallationManagerTests.m in Sources */,
 				4CA7329E24A2D021006AC99D /* NSURLRequest+HTTPBodyTesting.m in Sources */,
 				4CA732CF24A3B311006AC99D /* ANHHttpClientTests.m in Sources */,
@@ -2104,6 +2111,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CA732D824A3B312006AC99D /* MSNotificationHubTemplatesTests.m in Sources */,
+				2A7CB3582991F041005DB675 /* CompileObjCppTests.mm in Sources */,
 				4C01E9FE24BD1896003593A2 /* ANHHttpTestUtil.m in Sources */,
 				4CA732E524A3B38F006AC99D /* MSInstallationTemplateTests.m in Sources */,
 				4CA732A524A2D021006AC99D /* HTTPStubsMethodSwizzling.m in Sources */,

--- a/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.h
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.h
@@ -190,14 +190,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Sets the template for the installation template for the given key.
  *
- * @param template The `MSInstallationTemplate` object containing the installation template data.
+ * @param installationTemplate The `MSInstallationTemplate` object containing the installation template data.
  * @param key The key for the template.
  *
  * @returns YES if the template was added, else NO.
  *
  * @see MSInstallationTemplate
  */
-+ (BOOL)setTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key;
++ (BOOL)setTemplate:(MSInstallationTemplate *)installationTemplate forKey:(NSString *)key;
 
 /**
  * Removes the installation template for the given key.

--- a/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/MSNotificationHub.m
@@ -479,8 +479,8 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
 
 #pragma mark Templates
 
-+ (BOOL)setTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key {
-    return [sharedInstance setTemplate:template forKey:key];
++ (BOOL)setTemplate:(MSInstallationTemplate *)installationTemplate forKey:(NSString *)key {
+    return [sharedInstance setTemplate:installationTemplate forKey:key];
 }
 
 + (BOOL)removeTemplateForKey:(NSString *)key {
@@ -495,10 +495,10 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
     return [sharedInstance getTemplates];
 }
 
-- (BOOL)setTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key {
+- (BOOL)setTemplate:(MSInstallationTemplate *)installationTemplate forKey:(NSString *)key {
     MSInstallation *installation = [self getInstallation];
 
-    if ([installation setTemplate:template forKey:key]) {
+    if ([installation setTemplate:installationTemplate forKey:key]) {
         [self upsertInstallation:installation];
         return YES;
     }

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Model/MSInstallation.h
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Model/MSInstallation.h
@@ -44,14 +44,14 @@
 /**
 * Sets the template for the installation template for the given key.
 *
-* @param template The `MSInstallationTemplate` object containing the installation template data.
+* @param installationTemplate The `MSInstallationTemplate` object containing the installation template data.
 * @param key The key for the template.
 *
 * @returns YES if the template was added, else NO.
 *
 * @see MSInstallationTemplate
 */
-- (BOOL)setTemplate:(MSInstallationTemplate *)template forKey:(NSString *)key;
+- (BOOL)setTemplate:(MSInstallationTemplate *)installationTemplate forKey:(NSString *)key;
 
 /**
 * Removes the installation template for the given key.

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Model/MSInstallation.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Model/MSInstallation.m
@@ -192,10 +192,10 @@
 
 #pragma mark Templates
 
-- (BOOL)setTemplate:(MSInstallationTemplate *)template forKey:(NSString *)templateKey {
+- (BOOL)setTemplate:(MSInstallationTemplate *)installationTemplate forKey:(NSString *)templateKey {
     NSMutableDictionary<NSString *, MSInstallationTemplate *> *tmpTemplates = [NSMutableDictionary dictionaryWithDictionary:self.templates];
 
-    [tmpTemplates setObject:template forKey:templateKey];
+    [tmpTemplates setObject:installationTemplate forKey:templateKey];
     self.templates = tmpTemplates;
     self.isDirty = YES;
     return YES;

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Model/MSInstallationTemplate.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Model/MSInstallationTemplate.m
@@ -154,11 +154,11 @@
     return [self isEqualToMSInstallationTemplate:(MSInstallationTemplate *)object];
 }
 
-- (BOOL)isEqualToMSInstallationTemplate:(MSInstallationTemplate *)template {
+- (BOOL)isEqualToMSInstallationTemplate:(MSInstallationTemplate *)installationTemplate {
     // We have to check for nil values
-    BOOL isBodyEqual = body == template.body || [body isEqualToString:template.body];
-    BOOL isTagsSetEqual = [tags isEqualToSet:template.tags];
-    BOOL isHeadersDictionaryEqual = [headers isEqualToDictionary:template.headers];
+    BOOL isBodyEqual = body == installationTemplate.body || [body isEqualToString:installationTemplate.body];
+    BOOL isTagsSetEqual = [tags isEqualToSet:installationTemplate.tags];
+    BOOL isHeadersDictionaryEqual = [headers isEqualToDictionary:installationTemplate.headers];
     return isBodyEqual && isTagsSetEqual && isHeadersDictionaryEqual;
 }
 

--- a/WindowsAzureMessaging/WindowsAzureMessagingTests/CompileObjCppTests.mm
+++ b/WindowsAzureMessaging/WindowsAzureMessagingTests/CompileObjCppTests.mm
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import <XCTest/XCTest.h>
+
+@interface CompileObjCppTests : XCTestCase
+
+@end
+
+#import "WindowsAzureMessaging.h"
+
+@implementation CompileObjCppTests
+
+- (void)testCppCompilation {
+    // This test exists to verify that Objective C++ compilation succeeds.
+    // C++ introduces some new keywords (such as `template`), so we avoid using those keywords in public signatures.
+    MSInstallation *installation = [MSInstallation new];
+    XCTAssertNotNil(installation);
+}
+
+@end


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Remove usage of the `template` keyword in public signatures. This was causing compilation errors when building Objective C++ source files.

Introduce a unit test that utilizes the Objective C++ compiler, to prevent future issues.

## Related PRs or issues

ref: #136

## Misc

NOTE: I verified that the test added in CompileObjCppTests _does_ fail without the corresponding `template` -> `installationTemplate` changes. The test should help catch future C++ compilation issues.
