### PR TITLE
Fix error with load method, use initialize instead

### DIFF
--- a/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHDelegateForwarder.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHDelegateForwarder.m
@@ -18,7 +18,7 @@ static NSMutableArray<dispatch_block_t> *traceBuffer = nil;
 
 @synthesize enabled = _enabled;
 
-+ (void)load {
++ (void)initialize {
     traceBuffer = [NSMutableArray new];
 }
 

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHNotificationHubAppDelegateForwarder.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHNotificationHubAppDelegateForwarder.m
@@ -15,7 +15,7 @@ static ANHNotificationHubAppDelegateForwarder *sharedInstance = nil;
 
 @implementation ANHNotificationHubAppDelegateForwarder
 
-+ (void)load {
++ (void)initialize {
     [[ANHNotificationHubAppDelegateForwarder sharedInstance] setEnabledFromPlistForKey:kANHAppDelegateForwarderEnabledKey];
 
     // Register selectors to swizzle for Push.

--- a/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHUserNotificationCenterDelegateForwarder.m
+++ b/WindowsAzureMessaging/WindowsAzureMessaging/Internal/DelegateForwarder/ANHUserNotificationCenterDelegateForwarder.m
@@ -15,7 +15,7 @@ static ANHUserNotificationCenterDelegateForwarder *sharedInstance = nil;
 
 @implementation ANHUserNotificationCenterDelegateForwarder
 
-+ (void)load {
++ (void)initialize {
     [[ANHUserNotificationCenterDelegateForwarder sharedInstance]
         setEnabledFromPlistForKey:kANHUserNotificationCenterDelegateForwarderEnabledKey];
 


### PR DESCRIPTION
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Use initialize instead of load method to prevent errors because of increased startup time.

I noticed this problem when compiling the project myself in **XCode 14.2**, **iOS min target 13**.

As an additional note, just in case it helps to reproduce, my project is using Objective C++.
